### PR TITLE
Add projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The [Azuki](https://twitter.com/azukizen) team created ERC721A for its sale on 1
 
 ![Gas Savings](https://pbs.twimg.com/media/FIdILKpVQAEQ_5U?format=jpg&name=medium)
 
-For more information on how ERC721A works under the hood, please visit our [blog](https://www.azuki.com/erc721a). To find other projects that are using ERC721A, please visit [erc721a.org](https://www.erc721a.org).
+For more information on how ERC721A works under the hood, please visit our [blog](https://www.azuki.com/erc721a). To find other projects that are using ERC721A, please visit [erc721a.org](https://www.erc721a.org) and our [curated projects list](https://github.com/chiru-labs/ERC721A/blob/main/projects.md).
 
 **Chiru Labs is not liable for any outcomes as a result of using ERC721A.** DYOR.
 

--- a/projects.md
+++ b/projects.md
@@ -2,7 +2,7 @@
 
 Here are a list of projects that have or will be implementing ERC721A as part of their mint process. If your project is using ERC721A, feel free to open a PR and add it to the list!
 
-- Azuki | [Etherscan](https://etherscan.io/address/0xed5af388653567af2f388e6224dc7c4b3241c544) | [Twitter](https://twitter.com/AzukiZen) 
+- [Azuki](https://www.azuki.com/) | [Etherscan](https://etherscan.io/address/0xed5af388653567af2f388e6224dc7c4b3241c544) | [Twitter](https://twitter.com/AzukiZen) 
 - [Cereal Club](https://www.cerealclub.io/) | Etherscan | [Twitter](https://twitter.com/cerealclubnft)
 - The Lost Glitches | Etherscan | [Twitter](https://twitter.com/TheLostGlitches)
 - Standard Protocol | Etherscan | [Twitter](https://twitter.com/standardweb3)

--- a/projects.md
+++ b/projects.md
@@ -5,6 +5,6 @@ Here are a list of projects that have or will be implementing ERC721A as part of
 - [Azuki](https://www.azuki.com/) | [Etherscan](https://etherscan.io/address/0xed5af388653567af2f388e6224dc7c4b3241c544) | [Twitter](https://twitter.com/AzukiZen) 
 - [Cereal Club](https://www.cerealclub.io/) | Etherscan | [Twitter](https://twitter.com/cerealclubnft)
 - [The Lost Glitches](https://playlostglitches.com/) | [Etherscan](https://etherscan.io/address/0x8460bb8eb1251a923a31486af9567e500fc2f43f) | [Twitter](https://twitter.com/TheLostGlitches)
-- Standard Protocol | Etherscan | [Twitter](https://twitter.com/standardweb3)
+- [Standard Protocol](https://standard.tech/) | Etherscan | [Twitter](https://twitter.com/standardweb3)
 - [Kitty Crypto Gang](https://www.kittycryptogang.com/) | Etherscan | [Twitter](https://twitter.com/KittyCryptoGang)
 - [X Rabbits Club](https://xrabbits.club/) | [Etherscan](https://etherscan.io/address/0x534d37c630b7e4d2a6c1e064f3a2632739e9ee04) | [Twitter](https://twitter.com/XRabbitsClub)

--- a/projects.md
+++ b/projects.md
@@ -3,7 +3,7 @@
 Here are a list of projects that have or will be implementing ERC721A as part of their mint process. If your project is using ERC721A, feel free to open a PR and add it to the list!
 
 - Azuki | [Etherscan](https://etherscan.io/address/0xed5af388653567af2f388e6224dc7c4b3241c544) | [Twitter](https://twitter.com/AzukiZen) 
-- Cereal Club | Etherscan | [Twitter](https://twitter.com/cerealclubnft)
+- [Cereal Club](https://www.cerealclub.io/) | Etherscan | [Twitter](https://twitter.com/cerealclubnft)
 - The Lost Glitches | Etherscan | [Twitter](https://twitter.com/TheLostGlitches)
 - Standard Protocol | Etherscan | [Twitter](https://twitter.com/standardweb3)
 - [Kitty Crypto Gang](https://www.kittycryptogang.com/) | Etherscan | [Twitter](https://twitter.com/KittyCryptoGang)

--- a/projects.md
+++ b/projects.md
@@ -4,7 +4,7 @@ Here are a list of projects that have or will be implementing ERC721A as part of
 
 - [Azuki](https://www.azuki.com/) | [Etherscan](https://etherscan.io/address/0xed5af388653567af2f388e6224dc7c4b3241c544) | [Twitter](https://twitter.com/AzukiZen) 
 - [Cereal Club](https://www.cerealclub.io/) | Etherscan | [Twitter](https://twitter.com/cerealclubnft)
-- The Lost Glitches | Etherscan | [Twitter](https://twitter.com/TheLostGlitches)
+- [The Lost Glitches](https://playlostglitches.com/) | [Etherscan](https://etherscan.io/address/0x8460bb8eb1251a923a31486af9567e500fc2f43f) | [Twitter](https://twitter.com/TheLostGlitches)
 - Standard Protocol | Etherscan | [Twitter](https://twitter.com/standardweb3)
 - [Kitty Crypto Gang](https://www.kittycryptogang.com/) | Etherscan | [Twitter](https://twitter.com/KittyCryptoGang)
 - [X Rabbits Club](https://xrabbits.club/) | [Etherscan](https://etherscan.io/address/0x534d37c630b7e4d2a6c1e064f3a2632739e9ee04) | [Twitter](https://twitter.com/XRabbitsClub)

--- a/projects.md
+++ b/projects.md
@@ -7,4 +7,4 @@ Here are a list of projects that have or will be implementing ERC721A as part of
 - The Lost Glitches | Etherscan | [Twitter](https://twitter.com/TheLostGlitches)
 - Standard Protocol | Etherscan | [Twitter](https://twitter.com/standardweb3)
 - Kitty Crypto Gang | Etherscan | [Twitter](https://twitter.com/KittyCryptoGang)
-- X Rabbits Club | Etherscan | [Twitter](https://twitter.com/XRabbitsClub)
+- [X Rabbits Club](https://xrabbits.club/) | [Etherscan](https://etherscan.io/address/0x534d37c630b7e4d2a6c1e064f3a2632739e9ee04) | [Twitter](https://twitter.com/XRabbitsClub)

--- a/projects.md
+++ b/projects.md
@@ -6,5 +6,5 @@ Here are a list of projects that have or will be implementing ERC721A as part of
 - Cereal Club | Etherscan | [Twitter](https://twitter.com/cerealclubnft)
 - The Lost Glitches | Etherscan | [Twitter](https://twitter.com/TheLostGlitches)
 - Standard Protocol | Etherscan | [Twitter](https://twitter.com/standardweb3)
-- Kitty Crypto Gang | Etherscan | [Twitter](https://twitter.com/KittyCryptoGang)
+- [Kitty Crypto Gang](https://www.kittycryptogang.com/) | Etherscan | [Twitter](https://twitter.com/KittyCryptoGang)
 - [X Rabbits Club](https://xrabbits.club/) | [Etherscan](https://etherscan.io/address/0x534d37c630b7e4d2a6c1e064f3a2632739e9ee04) | [Twitter](https://twitter.com/XRabbitsClub)

--- a/projects.md
+++ b/projects.md
@@ -1,0 +1,10 @@
+## ERC721A Implementations
+
+Here are a list of projects that have or will be implementing ERC721A as part of their mint process. If your project is using ERC721A, feel free to open a PR and add it to the list!
+
+- Azuki | [Etherscan](https://etherscan.io/address/0xed5af388653567af2f388e6224dc7c4b3241c544) | [Twitter](https://twitter.com/AzukiZen) 
+- Cereal Club | Etherscan | [Twitter](https://twitter.com/cerealclubnft)
+- The Lost Glitches | Etherscan | [Twitter](https://twitter.com/TheLostGlitches)
+- Standard Protocol | Etherscan | [Twitter](https://twitter.com/standardweb3)
+- Kitty Crypto Gang | Etherscan | [Twitter](https://twitter.com/KittyCryptoGang)
+- X Rabbits Club | Etherscan | [Twitter](https://twitter.com/XRabbitsClub)


### PR DESCRIPTION
To make it easier to add your project to the list of projects using ERC721A, we've put together a markdown file of all the projects that have let us know about their implementation. Anyone is allowed to add their project to the list!