### PR TITLE
Implements batching of batches inside of safeMint

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,6 @@
 {
+  "printWidth": 120,
+  "singleQuote": true,
   "overrides": [
     {
       "files": "*.sol",

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -5,7 +5,6 @@ const { ZERO_ADDRESS } = constants;
 const RECEIVER_MAGIC_VALUE = '0x150b7a02';
 const GAS_MAGIC_VALUE = 20000;
 
-
 describe('ERC721A', function () {
   beforeEach(async function () {
     this.ERC721A = await ethers.getContractFactory('ERC721AMock');
@@ -23,26 +22,28 @@ describe('ERC721A', function () {
 
   context('with minted tokens', async function () {
     beforeEach(async function () {
-      const [owner, addr1, addr2, addr3] = await ethers.getSigners();
+      const [owner, addr1, addr2, addr3, addr4] = await ethers.getSigners();
       this.owner = owner;
       this.addr1 = addr1;
       this.addr2 = addr2;
       this.addr3 = addr3;
+      this.addr4 = addr4;
       await this.erc721a['safeMint(address,uint256)'](addr1.address, 1);
       await this.erc721a['safeMint(address,uint256)'](addr2.address, 2);
       await this.erc721a['safeMint(address,uint256)'](addr3.address, 3);
+      await this.erc721a['safeMint(address,uint256)'](addr4.address, 10);
     });
 
     describe('exists', async function () {
       it('verifies valid tokens', async function () {
-        for (let tokenId = 0; tokenId < 6; tokenId++) {
+        for (let tokenId = 0; tokenId < 16; tokenId++) {
           const exists = await this.erc721a.exists(tokenId);
           expect(exists).to.be.true;
         }
       });
 
       it('verifies invalid tokens', async function () {
-        const exists = await this.erc721a.exists(6);
+        const exists = await this.erc721a.exists(16);
         expect(exists).to.be.false;
       });
     });
@@ -53,12 +54,13 @@ describe('ERC721A', function () {
         expect(await this.erc721a.balanceOf(this.addr1.address)).to.equal('1');
         expect(await this.erc721a.balanceOf(this.addr2.address)).to.equal('2');
         expect(await this.erc721a.balanceOf(this.addr3.address)).to.equal('3');
+        expect(await this.erc721a.balanceOf(this.addr4.address)).to.equal('10');
       });
 
       it('throws an exception for the 0 address', async function () {
-        await expect(
-          this.erc721a.balanceOf(ZERO_ADDRESS)
-        ).to.be.revertedWith('ERC721A: balance query for the zero address');
+        await expect(this.erc721a.balanceOf(ZERO_ADDRESS)).to.be.revertedWith(
+          'ERC721A: balance query for the zero address'
+        );
       });
     });
 
@@ -68,6 +70,7 @@ describe('ERC721A', function () {
         expect(await this.erc721a.numberMinted(this.addr1.address)).to.equal('1');
         expect(await this.erc721a.numberMinted(this.addr2.address)).to.equal('2');
         expect(await this.erc721a.numberMinted(this.addr3.address)).to.equal('3');
+        expect(await this.erc721a.numberMinted(this.addr4.address)).to.equal('10');
       });
     });
 
@@ -76,10 +79,11 @@ describe('ERC721A', function () {
         expect(await this.erc721a.ownerOf(0)).to.equal(this.addr1.address);
         expect(await this.erc721a.ownerOf(1)).to.equal(this.addr2.address);
         expect(await this.erc721a.ownerOf(5)).to.equal(this.addr3.address);
+        expect(await this.erc721a.ownerOf(15)).to.equal(this.addr4.address);
       });
 
       it('reverts for an invalid token', async function () {
-        await expect(this.erc721a.ownerOf(10)).to.be.revertedWith('ERC721A: owner query for nonexistent token');
+        await expect(this.erc721a.ownerOf(16)).to.be.revertedWith('ERC721A: owner query for nonexistent token');
       });
     });
 
@@ -94,19 +98,19 @@ describe('ERC721A', function () {
       });
 
       it('rejects an invalid token owner', async function () {
-        await expect(
-          this.erc721a.connect(this.addr1).approve(this.addr2.address, tokenId2)
-        ).to.be.revertedWith('ERC721A: approval to current owner');
+        await expect(this.erc721a.connect(this.addr1).approve(this.addr2.address, tokenId2)).to.be.revertedWith(
+          'ERC721A: approval to current owner'
+        );
       });
 
       it('rejects an unapproved caller', async function () {
-        await expect(
-          this.erc721a.approve(this.addr2.address, tokenId)
-        ).to.be.revertedWith('ERC721A: approve caller is not owner nor approved for all');
+        await expect(this.erc721a.approve(this.addr2.address, tokenId)).to.be.revertedWith(
+          'ERC721A: approve caller is not owner nor approved for all'
+        );
       });
 
       it('does not get approved for invalid tokens', async function () {
-        await expect(this.erc721a.getApproved(10)).to.be.revertedWith('ERC721A: approved query for nonexistent token');
+        await expect(this.erc721a.getApproved(16)).to.be.revertedWith('ERC721A: approved query for nonexistent token');
       });
     });
 
@@ -120,9 +124,9 @@ describe('ERC721A', function () {
       });
 
       it('sets rejects approvals for non msg senders', async function () {
-        await expect(
-          this.erc721a.connect(this.addr1).setApprovalForAll(this.addr1.address, true)
-        ).to.be.revertedWith('ERC721A: approve to caller');
+        await expect(this.erc721a.connect(this.addr1).setApprovalForAll(this.addr1.address, true)).to.be.revertedWith(
+          'ERC721A: approve to caller'
+        );
       });
     });
 
@@ -146,9 +150,7 @@ describe('ERC721A', function () {
         });
 
         it('emits a Transfer event', async function () {
-          await expect(this.transferTx)
-            .to.emit(this.erc721a, 'Transfer')
-            .withArgs(from, to, tokenId);
+          await expect(this.transferTx).to.emit(this.erc721a, 'Transfer').withArgs(from, to, tokenId);
         });
 
         it('clears the approval for the token ID', async function () {
@@ -156,9 +158,7 @@ describe('ERC721A', function () {
         });
 
         it('emits an Approval event', async function () {
-          await expect(this.transferTx)
-            .to.emit(this.erc721a, 'Approval')
-            .withArgs(from, ZERO_ADDRESS, tokenId);
+          await expect(this.transferTx).to.emit(this.erc721a, 'Approval').withArgs(from, ZERO_ADDRESS, tokenId);
         });
 
         it('adjusts owners balances', async function () {
@@ -235,9 +235,7 @@ describe('ERC721A', function () {
     describe('safeMint', function () {
       it('successfully mints a single token', async function () {
         const mintTx = await this.erc721a['safeMint(address,uint256)'](this.receiver.address, 1);
-        await expect(mintTx)
-          .to.emit(this.erc721a, 'Transfer')
-          .withArgs(ZERO_ADDRESS, this.receiver.address, 0);
+        await expect(mintTx).to.emit(this.erc721a, 'Transfer').withArgs(ZERO_ADDRESS, this.receiver.address, 0);
         await expect(mintTx)
           .to.emit(this.receiver, 'Received')
           .withArgs(this.owner.address, ZERO_ADDRESS, 0, '0x', GAS_MAGIC_VALUE);
@@ -247,9 +245,7 @@ describe('ERC721A', function () {
       it('successfully mints multiple tokens', async function () {
         const mintTx = await this.erc721a['safeMint(address,uint256)'](this.receiver.address, 5);
         for (let tokenId = 0; tokenId < 5; tokenId++) {
-          await expect(mintTx)
-            .to.emit(this.erc721a, 'Transfer')
-            .withArgs(ZERO_ADDRESS, this.receiver.address, tokenId);
+          await expect(mintTx).to.emit(this.erc721a, 'Transfer').withArgs(ZERO_ADDRESS, this.receiver.address, tokenId);
           await expect(mintTx)
             .to.emit(this.receiver, 'Received')
             .withArgs(this.owner.address, ZERO_ADDRESS, 0, '0x', GAS_MAGIC_VALUE);
@@ -258,15 +254,9 @@ describe('ERC721A', function () {
       });
 
       it('rejects mints to the zero address', async function () {
-        await expect(
-          this.erc721a['safeMint(address,uint256)'](ZERO_ADDRESS, 1)
-        ).to.be.revertedWith('ERC721A: mint to the zero address');
-      });
-
-      it('rejects quantity > maxBatchSize', async function () {
-        await expect(
-          this.erc721a['safeMint(address,uint256)'](this.receiver.address, 6)
-        ).to.be.revertedWith('ERC721A: quantity to mint too high');
+        await expect(this.erc721a['safeMint(address,uint256)'](ZERO_ADDRESS, 1)).to.be.revertedWith(
+          'ERC721A: mint to the zero address'
+        );
       });
     });
   });


### PR DESCRIPTION
Modifies `safeMint` to be able to accept an arbitrary quantity which should simplify the API for a lot of use cases. 

Drawbacks: has a  minor impact on gas for the mint of 1 - `77395 -> 78188`. (optimizer enabled at 200)

For the cases of minting 10 with a maxBatchSize of 5 the overall gas is: 121709
![Screen Shot 2022-01-23 at 10 45 35 PM](https://user-images.githubusercontent.com/98291700/150718740-714dd5ea-b9d5-4bd1-8896-b7e38787bcbf.png)

Your token 0 is 15k gas more expensive than other tokens because `currentIndex` is not "warm". So tested it on tokens 1-10 to get proper gas.

