### PR TITLE
Fix hardhat config solidity version

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -9,7 +9,7 @@ if (process.env.REPORT_GAS) {
  * @type import('hardhat/config').HardhatUserConfig
  */
 module.exports = {
-  solidity: "0.8.4",
+  solidity: "0.8.11",
   gasReporter: {
     currency: 'USD',
   }


### PR DESCRIPTION
Oversight on my part when originally putting together the repo, changing to 0.8.11 to match the latest solidity version. Good catch from @AndreiD
