### PR TITLE
Remove `batchSize`

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -38,8 +38,6 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
 
     uint256 internal currentIndex = 0;
 
-    uint256 internal immutable maxBatchSize;
-
     // Token name
     string private _name;
 
@@ -59,19 +57,9 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
     // Mapping from owner to operator approvals
     mapping(address => mapping(address => bool)) private _operatorApprovals;
 
-    /**
-     * @dev
-     * `maxBatchSize` refers to how much a minter can mint at a time.
-     */
-    constructor(
-        string memory name_,
-        string memory symbol_,
-        uint256 maxBatchSize_
-    ) {
-        require(maxBatchSize_ > 0, 'ERC721A: max batch size must be nonzero');
+    constructor(string memory name_, string memory symbol_) {
         _name = name_;
         _symbol = symbol_;
-        maxBatchSize = maxBatchSize_;
     }
 
     /**
@@ -141,12 +129,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
     function ownershipOf(uint256 tokenId) internal view returns (TokenOwnership memory) {
         require(_exists(tokenId), 'ERC721A: owner query for nonexistent token');
 
-        uint256 lowestTokenToCheck;
-        if (tokenId >= maxBatchSize) {
-            lowestTokenToCheck = tokenId - maxBatchSize + 1;
-        }
-
-        for (uint256 curr = tokenId; curr >= lowestTokenToCheck; curr--) {
+        for (uint256 curr = tokenId; ; curr--) {
             TokenOwnership memory ownership = _ownerships[curr];
             if (ownership.addr != address(0)) {
                 return ownership;
@@ -309,7 +292,6 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
         require(to != address(0), 'ERC721A: mint to the zero address');
         // We know if the first token in the batch doesn't exist, the other ones don't as well, because of serial ordering.
         require(!_exists(startTokenId), 'ERC721A: token already minted');
-        require(quantity <= maxBatchSize, 'ERC721A: quantity to mint too high');
         require(quantity > 0, 'ERC721A: quantity must be greater 0');
 
         _beforeTokenTransfers(address(0), to, startTokenId, quantity);

--- a/contracts/mocks/ERC721AExplicitOwnershipMock.sol
+++ b/contracts/mocks/ERC721AExplicitOwnershipMock.sol
@@ -6,11 +6,7 @@ pragma solidity ^0.8.0;
 import '../extensions/ERC721AOwnersExplicit.sol';
 
 contract ERC721AOwnersExplicitMock is ERC721AOwnersExplicit {
-    constructor(
-        string memory name_,
-        string memory symbol_,
-        uint256 maxBatchSize_
-    ) ERC721A(name_, symbol_, maxBatchSize_) {}
+    constructor(string memory name_, string memory symbol_) ERC721A(name_, symbol_) {}
 
     function safeMint(address to, uint256 quantity) public {
         _safeMint(to, quantity);

--- a/contracts/mocks/ERC721AMock.sol
+++ b/contracts/mocks/ERC721AMock.sol
@@ -9,11 +9,7 @@ import '../ERC721A.sol';
 import '@openzeppelin/contracts/utils/Strings.sol';
 
 contract ERC721AMock is ERC721A {
-    constructor(
-        string memory name_,
-        string memory symbol_,
-        uint256 maxBatchSize_
-    ) ERC721A(name_, symbol_, maxBatchSize_) {}
+    constructor(string memory name_, string memory symbol_) ERC721A(name_, symbol_) {}
 
     function numberMinted(address owner) public view returns (uint256) {
         return _numberMinted(owner);

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -9,7 +9,7 @@ describe('ERC721A', function () {
   beforeEach(async function () {
     this.ERC721A = await ethers.getContractFactory('ERC721AMock');
     this.ERC721Receiver = await ethers.getContractFactory('ERC721ReceiverMock');
-    this.erc721a = await this.ERC721A.deploy('Azuki', 'AZUKI', 5);
+    this.erc721a = await this.ERC721A.deploy('Azuki', 'AZUKI');
     await this.erc721a.deployed();
   });
 
@@ -251,12 +251,6 @@ describe('ERC721A', function () {
       it('rejects mints to the zero address', async function () {
         await expect(this.erc721a['safeMint(address,uint256)'](ZERO_ADDRESS, 1)).to.be.revertedWith(
           'ERC721A: mint to the zero address'
-        );
-      });
-
-      it('rejects quantity > maxBatchSize', async function () {
-        await expect(this.erc721a['safeMint(address,uint256)'](this.receiver.address, 6)).to.be.revertedWith(
-          'ERC721A: quantity to mint too high'
         );
       });
 

--- a/test/extensions/ERC721AOwnersExplicit.test.js
+++ b/test/extensions/ERC721AOwnersExplicit.test.js
@@ -2,19 +2,16 @@ const { expect } = require('chai');
 const { constants } = require('@openzeppelin/test-helpers');
 const { ZERO_ADDRESS } = constants;
 
-
 describe('ERC721AOwnersExplicit', function () {
   beforeEach(async function () {
     this.ERC721AOwnersExplicit = await ethers.getContractFactory('ERC721AOwnersExplicitMock');
-    this.token = await this.ERC721AOwnersExplicit.deploy('Azuki', 'AZUKI', 5);
+    this.token = await this.ERC721AOwnersExplicit.deploy('Azuki', 'AZUKI');
     await this.token.deployed();
   });
 
   context('with no minted tokens', async function () {
     it('does not have enough tokens minted', async function () {
-      await expect(
-        this.token.setOwnersExplicit(1)
-      ).to.be.revertedWith('no tokens minted yet');
+      await expect(this.token.setOwnersExplicit(1)).to.be.revertedWith('no tokens minted yet');
     });
   });
 
@@ -34,9 +31,7 @@ describe('ERC721AOwnersExplicit', function () {
 
     describe('setOwnersExplicit', async function () {
       it('rejects 0 quantity', async function () {
-        await expect(
-          this.token.setOwnersExplicit(0)
-        ).to.be.revertedWith('quantity must be nonzero');
+        await expect(this.token.setOwnersExplicit(0)).to.be.revertedWith('quantity must be nonzero');
       });
 
       it('handles single increment properly', async function () {
@@ -83,9 +78,7 @@ describe('ERC721AOwnersExplicit', function () {
 
       it('rejects after all ownerships have been set', async function () {
         await this.token.setOwnersExplicit(6);
-        await expect(
-          this.token.setOwnersExplicit(1)
-        ).to.be.revertedWith('all ownerships have been set');
+        await expect(this.token.setOwnersExplicit(1)).to.be.revertedWith('all ownerships have been set');
       });
     });
   });


### PR DESCRIPTION
`batchSize` is not required. The implementation should be kept as close to the original as possible. Requiring a certain batch size is better dealt with in inheriting contracts.
Resolves #18 