### PR TITLE
added Miss Metaverse

### DIFF
--- a/projects.md
+++ b/projects.md
@@ -11,3 +11,4 @@ Here are a list of projects that have or will be implementing ERC721A as part of
 - [WhaleTogether](https://whaletogether.com/) | Etherscan | [Twitter](https://twitter.com/WhaleTogether)
 - [Pixel Piracy](https://pixelpiracy.io/) | Etherscan | [Twitter](https://twitter.com/pixelpiracynft)
 - [Dastardly Ducks](https://www.dastardlyducks.com) | [Etherscan](https://etherscan.io/address/0x5472896e283ebcb13924c659c9db594aa9dc05a4#code) | [Twitter](https://www.twitter.com/dastardlyducks)
+- [Miss Metaverse NFT](https://www.missmetaverse.io/) | [Etherscan] | [Twitter](https://twitter.com/MissMetaNFT)

--- a/projects.md
+++ b/projects.md
@@ -11,4 +11,4 @@ Here are a list of projects that have or will be implementing ERC721A as part of
 - [WhaleTogether](https://whaletogether.com/) | Etherscan | [Twitter](https://twitter.com/WhaleTogether)
 - [Pixel Piracy](https://pixelpiracy.io/) | [Etherscan](https://etherscan.io/address/0x1af1f96e6cbf2a038b056acac1603170f9967cb5) | [Twitter](https://twitter.com/pixelpiracynft)
 - [Dastardly Ducks](https://www.dastardlyducks.com) | [Etherscan](https://etherscan.io/address/0x5472896e283ebcb13924c659c9db594aa9dc05a4#code) | [Twitter](https://www.twitter.com/dastardlyducks)
-- [Miss Metaverse NFT](https://www.missmetaverse.io/) | [Etherscan] | [Twitter](https://twitter.com/MissMetaNFT)
+- [Miss Metaverse NFT](https://www.missmetaverse.io/) | Etherscan | [Twitter](https://twitter.com/MissMetaNFT)

--- a/projects.md
+++ b/projects.md
@@ -9,8 +9,6 @@ Here are a list of projects that have or will be implementing ERC721A as part of
 - [Kitty Crypto Gang](https://www.kittycryptogang.com/) | Etherscan | [Twitter](https://twitter.com/KittyCryptoGang)
 - [X Rabbits Club](https://xrabbits.club/) | [Etherscan](https://etherscan.io/address/0x534d37c630b7e4d2a6c1e064f3a2632739e9ee04) | [Twitter](https://twitter.com/XRabbitsClub)
 - [WhaleTogether](https://whaletogether.com/) | Etherscan | [Twitter](https://twitter.com/WhaleTogether)
-- [Pixel Piracy](https://pixelpiracy.io/) | Etherscan | [Twitter](https://twitter.com/pixelpiracynft)
-- [Dastardly Ducks](https://www.dastardlyducks.com) | [Etherscan](https://etherscan.io/address/0x5472896e283ebcb13924c659c9db594aa9dc05a4#code) | [Twitter](https://www.twitter.com/dastardlyducks)
 - [Pixel Piracy](https://pixelpiracy.io/) | [Etherscan](https://etherscan.io/address/0x1af1f96e6cbf2a038b056acac1603170f9967cb5) | [Twitter](https://twitter.com/pixelpiracynft)
 - [Dastardly Ducks](https://www.dastardlyducks.com) | [Etherscan](https://etherscan.io/address/0x5472896e283ebcb13924c659c9db594aa9dc05a4#code) | [Twitter](https://www.twitter.com/dastardlyducks)
 - [Miss Metaverse NFT](https://www.missmetaverse.io/) | [Etherscan] | [Twitter](https://twitter.com/MissMetaNFT)


### PR DESCRIPTION
Miss Metaverse will use ERC721A in their project. See (https://rinkeby.etherscan.io/address/0x78c31BEBDe7573C7AC9dD1bF064Ae690Ad3B36Cf#code) for Rinkbey test contract.