### PR TITLE
Save some gas with an unchecked block on transfer

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -19,6 +19,8 @@ import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
  * Assumes serials are sequentially minted starting at 0 (e.g. 0, 1, 2, 3..).
  *
  * Does not support burning tokens to address(0).
+ *
+ * Assumes that an owner cannot have more than the 2**128 (max value of uint128) of supply
  */
 contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable {
     using Address for address;

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -364,8 +364,13 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
         // Clear approvals from the previous owner
         _approve(address(0), tokenId, prevOwnership.addr);
 
-        _addressData[from].balance -= 1;
-        _addressData[to].balance += 1;
+        // Underflow of the sender's balance is impossible because we check for
+        // ownership above and the recipient's balance can't realistically overflow.
+        unchecked {
+            _addressData[from].balance -= 1;
+            _addressData[to].balance += 1;
+        }
+
         _ownerships[tokenId] = TokenOwnership(to, uint64(block.timestamp));
 
         // If the ownership slot of tokenId+1 is not explicitly set, that means the transfer initiator owns it.


### PR DESCRIPTION
Gas snapshot on latest master:

```
·-------------------------------------|----------------------------|-------------|-----------------------------·
|        Solc version: 0.8.11         ·  Optimizer enabled: false  ·  Runs: 200  ·  Block limit: 30000000 gas  │
······································|····························|·············|······························
|  Methods                                                                                                     │
················|·····················|·············|··············|·············|···············|··············
|  Contract     ·  Method             ·  Min        ·  Max         ·  Avg        ·  # calls      ·  usd (avg)  │
················|·····················|·············|··············|·············|···············|··············
|  ERC721AMock  ·  safeTransferFrom   ·          -  ·           -  ·      98763  ·           10  ·          -  │
················|·····················|·············|··············|·············|···············|··············
|  ERC721AMock  ·  transferFrom       ·          -  ·           -  ·      89328  ·            8  ·          -  │
················|·····················|·············|··············|·············|···············|··············
```

Gas snapshot post-change:
```
·-------------------------------------|----------------------------|-------------|-----------------------------·
|        Solc version: 0.8.11         ·  Optimizer enabled: false  ·  Runs: 200  ·  Block limit: 30000000 gas  │
······································|····························|·············|······························
|  Methods                                                                                                     │
················|·····················|·············|··············|·············|···············|··············
|  Contract     ·  Method             ·  Min        ·  Max         ·  Avg        ·  # calls      ·  usd (avg)  │
················|·····················|·············|··············|·············|···············|··············
|  ERC721AMock  ·  safeTransferFrom   ·          -  ·           -  ·      98369  ·           10  ·          -  │
················|·····················|·············|··············|·············|···············|··············
|  ERC721AMock  ·  transferFrom       ·          -  ·           -  ·      88934  ·            8  ·          -  │
················|·····················|·············|··············|·············|···············|··············
```

![image](https://user-images.githubusercontent.com/5074153/151395711-4c8f5c7f-c315-4686-a36f-3757444fef6e.png)
