### PR TITLE
Removed batchSize from constructor in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pragma solidity ^0.8.0;
 import "erc721a/contracts/ERC721A.sol";
 
 contract Azuki is ERC721A {
-  constructor() ERC721A("Azuki", "AZUKI", 5) {}
+  constructor() ERC721A("Azuki", "AZUKI") {}
 
   function mint(uint256 quantity) external payable {
     // _safeMint's second argument now takes in a quantity, not a tokenId.


### PR DESCRIPTION
batchSize in constructor not needed in the README after recent commit (https://github.com/chiru-labs/ERC721A/commit/3e1b7defa66eab4f16975b489c213bea3c66e6dd).