### PR TITLE
Fix implementation example with correct number of constructor arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pragma solidity ^0.8.0;
 import "erc721a/contracts/ERC721A.sol";
 
 contract Azuki is ERC721A {
-  constructor() ERC721A("Azuki", "AZUKI", 5) {}
+  constructor() ERC721A("Azuki", "AZUKI") {}
 
   function mint(uint256 quantity) external payable {
     // _safeMint's second argument now takes in a quantity, not a tokenId.


### PR DESCRIPTION
The current implementation example of ERC721A provided in the README.md file is not working.

ERC721A inherited constructor requires only 2 arguments since the argument `uint256 maxBatchSize_` has been removed. The example has yet to be updated and still passes the `maxBatchSize_` arguments, leading to a compilation error.
