### PR TITLE
Assigning values to structs individually instead of a single assignment

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -296,12 +296,11 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
 
         _beforeTokenTransfers(address(0), to, startTokenId, quantity);
 
-        AddressData memory addressData = _addressData[to];
-        _addressData[to] = AddressData(
-            addressData.balance + uint128(quantity),
-            addressData.numberMinted + uint128(quantity)
-        );
-        _ownerships[startTokenId] = TokenOwnership(to, uint64(block.timestamp));
+		_addressData[to].balance += uint128(quantity);
+		_addressData[to].numberMinted += uint128(quantity);
+
+		_ownerships[startTokenId].addr = to;
+		_ownerships[startTokenId].startTimestamp = uint64(block.timestamp);
 
         uint256 updatedIndex = startTokenId;
 

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -355,14 +355,16 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
             _addressData[to].balance += 1;
         }
 
-        _ownerships[tokenId] = TokenOwnership(to, uint64(block.timestamp));
+        _ownerships[tokenId].addr = to;
+        _ownerships[tokenId].startTimestamp = uint64(block.timestamp);
 
         // If the ownership slot of tokenId+1 is not explicitly set, that means the transfer initiator owns it.
         // Set the slot of tokenId+1 explicitly in storage to maintain correctness for ownerOf(tokenId+1) calls.
         uint256 nextTokenId = tokenId + 1;
         if (_ownerships[nextTokenId].addr == address(0)) {
             if (_exists(nextTokenId)) {
-                _ownerships[nextTokenId] = TokenOwnership(prevOwnership.addr, prevOwnership.startTimestamp);
+                _ownerships[nextTokenId].addr = prevOwnership.addr;
+                _ownerships[nextTokenId].startTimestamp = prevOwnership.startTimestamp;
             }
         }
 

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -296,11 +296,11 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
 
         _beforeTokenTransfers(address(0), to, startTokenId, quantity);
 
-		_addressData[to].balance += uint128(quantity);
-		_addressData[to].numberMinted += uint128(quantity);
+        _addressData[to].balance += uint128(quantity);
+        _addressData[to].numberMinted += uint128(quantity);
 
-		_ownerships[startTokenId].addr = to;
-		_ownerships[startTokenId].startTimestamp = uint64(block.timestamp);
+        _ownerships[startTokenId].addr = to;
+        _ownerships[startTokenId].startTimestamp = uint64(block.timestamp);
 
         uint256 updatedIndex = startTokenId;
 

--- a/contracts/extensions/ERC721AOwnersExplicit.sol
+++ b/contracts/extensions/ERC721AOwnersExplicit.sol
@@ -26,7 +26,8 @@ abstract contract ERC721AOwnersExplicit is ERC721A {
         for (uint256 i = oldNextOwnerToSet; i <= endIndex; i++) {
             if (_ownerships[i].addr == address(0)) {
                 TokenOwnership memory ownership = ownershipOf(i);
-                _ownerships[i] = TokenOwnership(ownership.addr, ownership.startTimestamp);
+                _ownerships[i].addr = ownership.addr;
+                _ownerships[i].startTimestamp = ownership.startTimestamp;
             }
         }
         nextOwnerToExplicitlySet = endIndex + 1;


### PR DESCRIPTION
[Cheaper by about 230 gas per mint and 15,000 gas on deployment.](https://github.com/DaniPopes/soltracts/commit/dd75437e42bd696383b5a859b06e1913055909a8) These savings are just for the mint ones, didn't test transfer.

[Source:](https://medium.com/coinmonks/gas-optimization-in-solidity-part-i-variables-9d5775e43dde)
> It is more gas efficient to initialize a tightly packed struct with separate assignments instead of a single assignment. Separate assignments makes it easier for the optimizer to update all the variables at once.