### PR TITLE
Add gas optimizations

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -294,8 +294,6 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
     ) internal {
         uint256 startTokenId = currentIndex;
         require(to != address(0), 'ERC721A: mint to the zero address');
-        // We know if the first token in the batch doesn't exist, the other ones don't as well, because of serial ordering.
-        require(!_exists(startTokenId), 'ERC721A: token already minted');
         require(quantity > 0, 'ERC721A: quantity must be greater than 0');
 
         _beforeTokenTransfers(address(0), to, startTokenId, quantity);

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -36,7 +36,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
         uint128 numberMinted;
     }
 
-    uint256 internal currentIndex = 0;
+    uint256 internal currentIndex;
 
     // Token name
     string private _name;
@@ -85,12 +85,12 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
     function tokenOfOwnerByIndex(address owner, uint256 index) public view override returns (uint256) {
         require(index < balanceOf(owner), 'ERC721A: owner index out of bounds');
         uint256 numMintedSoFar = totalSupply();
-        uint256 tokenIdsIdx = 0;
-        address currOwnershipAddr = address(0);
+        uint256 tokenIdsIdx;
+        address currOwnershipAddr;
 
         // Counter overflow is incredibly unrealistic.
         unchecked {
-            for (uint256 i = 0; i < numMintedSoFar; i++) {
+            for (uint256 i; i < numMintedSoFar; i++) {
                 TokenOwnership memory ownership = _ownerships[i];
                 if (ownership.addr != address(0)) {
                     currOwnershipAddr = ownership.addr;
@@ -313,7 +313,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
 
             uint256 updatedIndex = startTokenId;
 
-            for (uint256 i = 0; i < quantity; i++) {
+            for (uint256 i; i < quantity; i++) {
                 emit Transfer(address(0), to, updatedIndex);
                 require(
                     _checkOnERC721Received(address(0), to, updatedIndex, _data),

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -336,7 +336,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
 
             uint256 updatedIndex = startTokenId;
 
-            for (uint256 i = 0; i < quantity; i++) {
+            for (uint256 i; i < quantity; i++) {
                 emit Transfer(address(0), to, updatedIndex);
                 if (safe) {
                     require(
@@ -347,6 +347,8 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
 
                 updatedIndex++;
             }
+
+            currentIndex = updatedIndex;
         }
 
         _afterTokenTransfers(address(0), to, startTokenId, quantity);

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -306,7 +306,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
         _beforeTokenTransfers(address(0), to, startTokenId, quantity);
 
         // Overflows are incredibly unrealistic.
-        // balance or numberMinted overflow if current value of either + quantity > 3.4e38 (2**128)
+        // balance or numberMinted overflows if current balance or numberMinted + quantity > 3.4e38 (2**128)
         // updatedIndex overflows if currentIndex + quantity > 1.56e77 (2**256)
         unchecked {
             _addressData[to].balance += uint128(quantity);

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -306,8 +306,8 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
         _beforeTokenTransfers(address(0), to, startTokenId, quantity);
 
         // Overflows are incredibly unrealistic.
-        // balance or numberMinted overflows if current balance or numberMinted + quantity > 3.4e38 (2**128)
-        // updatedIndex overflows if currentIndex + quantity > 1.56e77 (2**256)
+        // balance or numberMinted overflow if current value of either + quantity > 3.4e38 (2**128) - 1
+        // updatedIndex overflows if currentIndex + quantity > 1.56e77 (2**256) - 1
         unchecked {
             _addressData[to].balance += uint128(quantity);
             _addressData[to].numberMinted += uint128(quantity);

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -306,7 +306,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
         _beforeTokenTransfers(address(0), to, startTokenId, quantity);
 
         // Overflows are incredibly unrealistic.
-        // balance or numberMinted overflows if current balance or numberMinted + quantity > 3.4e38 (2**128)
+        // balance or numberMinted overflow if current value of either + quantity > 3.4e38 (2**128)
         // updatedIndex overflows if currentIndex + quantity > 1.56e77 (2**256)
         unchecked {
             _addressData[to].balance += uint128(quantity);

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -176,7 +176,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
         require(_exists(tokenId), 'ERC721Metadata: URI query for nonexistent token');
 
         string memory baseURI = _baseURI();
-        return bytes(baseURI).length > 0 ? string(abi.encodePacked(baseURI, tokenId.toString())) : '';
+        return bytes(baseURI).length != 0 ? string(abi.encodePacked(baseURI, tokenId.toString())) : '';
     }
 
     /**
@@ -299,7 +299,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
     ) internal {
         uint256 startTokenId = currentIndex;
         require(to != address(0), 'ERC721A: mint to the zero address');
-        require(quantity > 0, 'ERC721A: quantity must be greater than 0');
+        require(quantity != 0, 'ERC721A: quantity must be greater than 0');
 
         _beforeTokenTransfers(address(0), to, startTokenId, quantity);
 

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -138,10 +138,12 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
     function ownershipOf(uint256 tokenId) internal view returns (TokenOwnership memory) {
         require(_exists(tokenId), 'ERC721A: owner query for nonexistent token');
 
-        for (uint256 curr = tokenId; ; curr--) {
-            TokenOwnership memory ownership = _ownerships[curr];
-            if (ownership.addr != address(0)) {
-                return ownership;
+        unchecked {
+            for (uint256 curr = tokenId; curr >= 0; curr--) {
+                TokenOwnership memory ownership = _ownerships[curr];
+                if (ownership.addr != address(0)) {
+                    return ownership;
+                }
             }
         }
 

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -87,18 +87,23 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
         uint256 numMintedSoFar = totalSupply();
         uint256 tokenIdsIdx = 0;
         address currOwnershipAddr = address(0);
-        for (uint256 i = 0; i < numMintedSoFar; i++) {
-            TokenOwnership memory ownership = _ownerships[i];
-            if (ownership.addr != address(0)) {
-                currOwnershipAddr = ownership.addr;
-            }
-            if (currOwnershipAddr == owner) {
-                if (tokenIdsIdx == index) {
-                    return i;
+
+        // Counter overflow is incredibly unrealistic.
+        unchecked {
+            for (uint256 i = 0; i < numMintedSoFar; i++) {
+                TokenOwnership memory ownership = _ownerships[i];
+                if (ownership.addr != address(0)) {
+                    currOwnershipAddr = ownership.addr;
                 }
-                tokenIdsIdx++;
+                if (currOwnershipAddr == owner) {
+                    if (tokenIdsIdx == index) {
+                        return i;
+                    }
+                    tokenIdsIdx++;
+                }
             }
         }
+
         revert('ERC721A: unable to get token of owner by index');
     }
 
@@ -298,24 +303,28 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
 
         _beforeTokenTransfers(address(0), to, startTokenId, quantity);
 
-        _addressData[to].balance += uint128(quantity);
-        _addressData[to].numberMinted += uint128(quantity);
+        // Balance, number minted and counter overflow is incredibly unrealistic.
+        unchecked {
+            _addressData[to].balance += uint128(quantity);
+            _addressData[to].numberMinted += uint128(quantity);
 
-        _ownerships[startTokenId].addr = to;
-        _ownerships[startTokenId].startTimestamp = uint64(block.timestamp);
+            _ownerships[startTokenId].addr = to;
+            _ownerships[startTokenId].startTimestamp = uint64(block.timestamp);
 
-        uint256 updatedIndex = startTokenId;
+            uint256 updatedIndex = startTokenId;
 
-        for (uint256 i = 0; i < quantity; i++) {
-            emit Transfer(address(0), to, updatedIndex);
-            require(
-                _checkOnERC721Received(address(0), to, updatedIndex, _data),
-                'ERC721A: transfer to non ERC721Receiver implementer'
-            );
-            updatedIndex++;
+            for (uint256 i = 0; i < quantity; i++) {
+                emit Transfer(address(0), to, updatedIndex);
+                require(
+                    _checkOnERC721Received(address(0), to, updatedIndex, _data),
+                    'ERC721A: transfer to non ERC721Receiver implementer'
+                );
+                updatedIndex++;
+            }
+
+            currentIndex = updatedIndex;
         }
 
-        currentIndex = updatedIndex;
         _afterTokenTransfers(address(0), to, startTokenId, quantity);
     }
 
@@ -352,21 +361,22 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
 
         // Underflow of the sender's balance is impossible because we check for
         // ownership above and the recipient's balance can't realistically overflow.
+        // Counter overflow is incredibly unrealistic.
         unchecked {
             _addressData[from].balance -= 1;
             _addressData[to].balance += 1;
-        }
 
-        _ownerships[tokenId].addr = to;
-        _ownerships[tokenId].startTimestamp = uint64(block.timestamp);
+            _ownerships[tokenId].addr = to;
+            _ownerships[tokenId].startTimestamp = uint64(block.timestamp);
 
-        // If the ownership slot of tokenId+1 is not explicitly set, that means the transfer initiator owns it.
-        // Set the slot of tokenId+1 explicitly in storage to maintain correctness for ownerOf(tokenId+1) calls.
-        uint256 nextTokenId = tokenId + 1;
-        if (_ownerships[nextTokenId].addr == address(0)) {
-            if (_exists(nextTokenId)) {
-                _ownerships[nextTokenId].addr = prevOwnership.addr;
-                _ownerships[nextTokenId].startTimestamp = prevOwnership.startTimestamp;
+            // If the ownership slot of tokenId+1 is not explicitly set, that means the transfer initiator owns it.
+            // Set the slot of tokenId+1 explicitly in storage to maintain correctness for ownerOf(tokenId+1) calls.
+            uint256 nextTokenId = tokenId + 1;
+            if (_ownerships[nextTokenId].addr == address(0)) {
+                if (_exists(nextTokenId)) {
+                    _ownerships[nextTokenId].addr = prevOwnership.addr;
+                    _ownerships[nextTokenId].startTimestamp = prevOwnership.startTimestamp;
+                }
             }
         }
 

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -307,7 +307,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
 
         // Overflows are incredibly unrealistic.
         // balance or numberMinted overflows if current balance or numberMinted + quantity > 3.4e38 (2**128)
-        // updatedIndex overflows if currentIndex + amount > 1.56e77 (2**256)
+        // updatedIndex overflows if currentIndex + quantity > 1.56e77 (2**256)
         unchecked {
             _addressData[to].balance += uint128(quantity);
             _addressData[to].numberMinted += uint128(quantity);

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -88,7 +88,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
         uint256 tokenIdsIdx;
         address currOwnershipAddr;
 
-        // Counter overflow is incredibly unrealistic.
+        // Counter overflow is impossible as the loop breaks when uint256 i is equal to another uint256 numMintedSoFar.
         unchecked {
             for (uint256 i; i < numMintedSoFar; i++) {
                 TokenOwnership memory ownership = _ownerships[i];
@@ -303,7 +303,9 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
 
         _beforeTokenTransfers(address(0), to, startTokenId, quantity);
 
-        // Balance, number minted and counter overflow is incredibly unrealistic.
+        // Overflows are incredibly unrealistic.
+        // balance or numberMinted overflows if current balance or numberMinted + quantity > 3.4e38 (2**128)
+        // updatedIndex overflows if currentIndex + amount > 1.56e77 (2**256)
         unchecked {
             _addressData[to].balance += uint128(quantity);
             _addressData[to].numberMinted += uint128(quantity);
@@ -361,7 +363,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
 
         // Underflow of the sender's balance is impossible because we check for
         // ownership above and the recipient's balance can't realistically overflow.
-        // Counter overflow is incredibly unrealistic.
+        // Counter overflow is incredibly unrealistic as tokenId would have to be 2**256.
         unchecked {
             _addressData[from].balance -= 1;
             _addressData[to].balance += 1;

--- a/contracts/extensions/ERC721AOwnersExplicit.sol
+++ b/contracts/extensions/ERC721AOwnersExplicit.sol
@@ -6,30 +6,36 @@ pragma solidity ^0.8.0;
 import '../ERC721A.sol';
 
 abstract contract ERC721AOwnersExplicit is ERC721A {
-    uint256 public nextOwnerToExplicitlySet = 0;
+    uint256 public nextOwnerToExplicitlySet;
 
     /**
      * @dev Explicitly set `owners` to eliminate loops in future calls of ownerOf().
      */
     function _setOwnersExplicit(uint256 quantity) internal {
-        require(quantity > 0, 'quantity must be nonzero');
-        require(currentIndex > 0, 'no tokens minted yet');
+        require(quantity != 0, 'quantity must be nonzero');
+        require(currentIndex != 0, 'no tokens minted yet');
         require(nextOwnerToExplicitlySet < currentIndex, 'all ownerships have been set');
 
-        uint256 oldNextOwnerToSet = nextOwnerToExplicitlySet;
-        uint256 endIndex = oldNextOwnerToSet + quantity - 1;
-        // Set the end index to be the last token index
-        if (endIndex > currentIndex - 1) {
-            endIndex = currentIndex - 1;
-        }
+        // Index underflow is impossible.
+        // Counter or index overflow is incredibly unrealistic.
+        unchecked {
+            uint256 oldNextOwnerToSet = nextOwnerToExplicitlySet;
+            uint256 endIndex = oldNextOwnerToSet + quantity - 1;
 
-        for (uint256 i = oldNextOwnerToSet; i <= endIndex; i++) {
-            if (_ownerships[i].addr == address(0)) {
-                TokenOwnership memory ownership = ownershipOf(i);
-                _ownerships[i].addr = ownership.addr;
-                _ownerships[i].startTimestamp = ownership.startTimestamp;
+            // Set the end index to be the last token index
+            if (endIndex + 1 > currentIndex) {
+                endIndex = currentIndex - 1;
             }
+
+            for (uint256 i = oldNextOwnerToSet; i <= endIndex; i++) {
+                if (_ownerships[i].addr == address(0)) {
+                    TokenOwnership memory ownership = ownershipOf(i);
+                    _ownerships[i].addr = ownership.addr;
+                    _ownerships[i].startTimestamp = ownership.startTimestamp;
+                }
+            }
+
+            nextOwnerToExplicitlySet = endIndex + 1;
         }
-        nextOwnerToExplicitlySet = endIndex + 1;
     }
 }

--- a/contracts/extensions/ERC721AOwnersExplicit.sol
+++ b/contracts/extensions/ERC721AOwnersExplicit.sol
@@ -20,15 +20,14 @@ abstract contract ERC721AOwnersExplicit is ERC721A {
         // Index underflow is impossible.
         // Counter or index overflow is incredibly unrealistic.
         unchecked {
-            uint256 oldNextOwnerToSet = _nextOwnerToExplicitlySet;
-            uint256 endIndex = oldNextOwnerToSet + quantity - 1;
+            uint256 endIndex = _nextOwnerToExplicitlySet + quantity - 1;
 
             // Set the end index to be the last token index
             if (endIndex + 1 > currentIndex) {
                 endIndex = currentIndex - 1;
             }
 
-            for (uint256 i = oldNextOwnerToSet; i <= endIndex; i++) {
+            for (uint256 i = _nextOwnerToExplicitlySet; i <= endIndex; i++) {
                 if (_ownerships[i].addr == address(0)) {
                     TokenOwnership memory ownership = ownershipOf(i);
                     _ownerships[i].addr = ownership.addr;

--- a/contracts/extensions/ERC721AOwnersExplicit.sol
+++ b/contracts/extensions/ERC721AOwnersExplicit.sol
@@ -14,12 +14,13 @@ abstract contract ERC721AOwnersExplicit is ERC721A {
     function _setOwnersExplicit(uint256 quantity) internal {
         require(quantity != 0, 'quantity must be nonzero');
         require(currentIndex != 0, 'no tokens minted yet');
-        require(nextOwnerToExplicitlySet < currentIndex, 'all ownerships have been set');
+        uint256 _nextOwnerToExplicitlySet = nextOwnerToExplicitlySet;
+        require(_nextOwnerToExplicitlySet < currentIndex, 'all ownerships have been set');
 
         // Index underflow is impossible.
         // Counter or index overflow is incredibly unrealistic.
         unchecked {
-            uint256 oldNextOwnerToSet = nextOwnerToExplicitlySet;
+            uint256 oldNextOwnerToSet = _nextOwnerToExplicitlySet;
             uint256 endIndex = oldNextOwnerToSet + quantity - 1;
 
             // Set the end index to be the last token index


### PR DESCRIPTION
Wrote up a few optimizations on the main contracts, open to feedback especially for [the unchecked blocks](https://github.com/chiru-labs/ERC721A/commit/ae1cdcff0eb73c3b5a12034664a260a60486791f) if you think that over/underflow checks are needed in those functions.

[1b32797:](https://github.com/chiru-labs/ERC721A/commit/1b32797fd57660f2463500960d89bedf9f1cf8a5) _exists(uint256 id) returns id < currentIndex, and we call it with currentIndex, which always results in it returning false.

[ae1cdcf:](https://github.com/chiru-labs/ERC721A/commit/ae1cdcff0eb73c3b5a12034664a260a60486791f) Explanations in the code comments.

[5fca737:](https://github.com/chiru-labs/ERC721A/commit/5fca737705af62cf3c04f546fc9e1a588a03e846) Initializing a variable with a 0 is more expensive than not doing so, even if both results are the same. [Source:](https://medium.com/coinmonks/gas-optimization-in-solidity-part-i-variables-9d5775e43dde) 
> uint256 value; is cheaper than uint256 value = 0;

[c23e2e0:](https://github.com/chiru-labs/ERC721A/commit/c23e2e07b41453f3f366f6b0a1edb281aa6d5c3d) All values are integers which cannot be negative, saves a few opcodes.

[ee2abe2:](https://github.com/chiru-labs/ERC721A/commit/ee2abe273c77060e25535ac99876c073f4d9df40) Previous changes applied to `ERC721AOwnersExplicit`.

[81daf25:](https://github.com/chiru-labs/ERC721A/commit/81daf257a9443d24da2aa5707ef303c09c77c664) Loading `nextOwnerToExplicitlySet` into memory saves an SLOAD opcode later on line 23.