### PR TITLE
Add _mint function

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -292,9 +292,9 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
         uint256 quantity,
         bytes memory _data
     ) internal {
-        uint256 startTokenId = _mintHelper(to, quantity);
+        uint256 firstTokenMinted = _mintHelper(to, quantity);
 
-        uint256 updatedIndex = startTokenId;
+        uint256 updatedIndex = firstTokenMinted;
         for (uint256 i = 0; i < quantity; i++) {
             emit Transfer(address(0), to, updatedIndex);
             require(
@@ -305,7 +305,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
         }
 
         currentIndex = updatedIndex;
-        _afterTokenTransfers(address(0), to, startTokenId, quantity);
+        _afterTokenTransfers(address(0), to, firstTokenMinted, quantity);
     }
 
     /**
@@ -319,18 +319,28 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
      * Emits a {Transfer} event.
      */
     function _mint(address to, uint256 quantity) internal {
-        uint256 startTokenId = _mintHelper(to, quantity);
+        uint256 firstTokenMinted = _mintHelper(to, quantity);
 
-        uint256 updatedIndex = startTokenId;
+        uint256 updatedIndex = firstTokenMinted;
         for (uint256 i = 0; i < quantity; i++) {
             emit Transfer(address(0), to, updatedIndex);
             updatedIndex++;
         }
 
         currentIndex = updatedIndex;
-        _afterTokenTransfers(address(0), to, startTokenId, quantity);
+        _afterTokenTransfers(address(0), to, firstTokenMinted, quantity);
     }
 
+    /**
+     * @dev Helper function for minting batch tokens.
+     *
+     * Requirements:
+     *
+     * - `to` cannot be the zero address.
+     * - `quantity` must be greater than 0.
+     *
+     * Returns the token id of the first token minted
+     */
     function _mintHelper(address to, uint256 quantity) internal returns (uint256) {
         uint256 startTokenId = currentIndex;
         require(to != address(0), 'ERC721A: mint to the zero address');

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -282,7 +282,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
      *
      * Requirements:
      *
-     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called for each safe transfer.
      * - `quantity` must be greater than 0.
      *
      * Emits a {Transfer} event.

--- a/contracts/mocks/ERC721AMock.sol
+++ b/contracts/mocks/ERC721AMock.sol
@@ -34,7 +34,12 @@ contract ERC721AMock is ERC721A {
         _safeMint(to, quantity, _data);
     }
 
-    function mint(address to, uint256 quantity) public {
-        _mint(to, quantity);
+    function mint(
+        address to,
+        uint256 quantity,
+        bytes memory _data,
+        bool safe
+    ) public {
+        _mint(to, quantity, _data, safe);
     }
 }

--- a/contracts/mocks/ERC721AMock.sol
+++ b/contracts/mocks/ERC721AMock.sol
@@ -33,4 +33,8 @@ contract ERC721AMock is ERC721A {
     ) public {
         _safeMint(to, quantity, _data);
     }
+
+    function mint(address to, uint256 quantity) public {
+        _mint(to, quantity);
+    }
 }

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -259,6 +259,49 @@ describe('ERC721A', function () {
           'ERC721A: quantity must be greater than 0'
         );
       });
+
+      it('reverts for non-receivers', async function () {
+        const nonReceiver = this.erc721a;
+        await expect(this.erc721a['safeMint(address,uint256)'](nonReceiver.address, 1)).to.be.revertedWith(
+          'ERC721A: transfer to non ERC721Receiver implementer'
+        );
+      });
+    });
+
+    describe('mint', function () {
+      it('successfully mints a single token', async function () {
+        const mintTx = await this.erc721a['mint(address,uint256)'](this.receiver.address, 1);
+        await expect(mintTx).to.emit(this.erc721a, 'Transfer').withArgs(ZERO_ADDRESS, this.receiver.address, 0);
+        await expect(mintTx).to.not.emit(this.receiver, 'Received')
+        expect(await this.erc721a.ownerOf(0)).to.equal(this.receiver.address);
+      });
+
+      it('successfully mints multiple tokens', async function () {
+        const mintTx = await this.erc721a['mint(address,uint256)'](this.receiver.address, 5);
+        for (let tokenId = 0; tokenId < 5; tokenId++) {
+          await expect(mintTx).to.emit(this.erc721a, 'Transfer').withArgs(ZERO_ADDRESS, this.receiver.address, tokenId);
+          await expect(mintTx).to.not.emit(this.receiver, 'Received')
+          expect(await this.erc721a.ownerOf(tokenId)).to.equal(this.receiver.address);
+        }
+      });
+
+      it('does not revert for non-receivers', async function () {
+        const nonReceiver = this.erc721a;
+        await this.erc721a['mint(address,uint256)'](nonReceiver.address, 1);
+        expect(await this.erc721a.ownerOf(0)).to.equal(nonReceiver.address);
+      });
+
+      it('rejects mints to the zero address', async function () {
+        await expect(this.erc721a['mint(address,uint256)'](ZERO_ADDRESS, 1)).to.be.revertedWith(
+          'ERC721A: mint to the zero address'
+        );
+      });
+
+      it('requires quantity to be greater than 0', async function () {
+        await expect(this.erc721a['mint(address,uint256)'](this.owner.address, 0)).to.be.revertedWith(
+          'ERC721A: quantity must be greater than 0'
+        );
+      });
     });
   });
 });

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -269,15 +269,17 @@ describe('ERC721A', function () {
     });
 
     describe('mint', function () {
+      const data = '0x42';
+
       it('successfully mints a single token', async function () {
-        const mintTx = await this.erc721a['mint(address,uint256)'](this.receiver.address, 1);
+        const mintTx = await this.erc721a.mint(this.receiver.address, 1, data, false);
         await expect(mintTx).to.emit(this.erc721a, 'Transfer').withArgs(ZERO_ADDRESS, this.receiver.address, 0);
         await expect(mintTx).to.not.emit(this.receiver, 'Received')
         expect(await this.erc721a.ownerOf(0)).to.equal(this.receiver.address);
       });
 
       it('successfully mints multiple tokens', async function () {
-        const mintTx = await this.erc721a['mint(address,uint256)'](this.receiver.address, 5);
+        const mintTx = await this.erc721a.mint(this.receiver.address, 5, data, false);
         for (let tokenId = 0; tokenId < 5; tokenId++) {
           await expect(mintTx).to.emit(this.erc721a, 'Transfer').withArgs(ZERO_ADDRESS, this.receiver.address, tokenId);
           await expect(mintTx).to.not.emit(this.receiver, 'Received')
@@ -287,18 +289,18 @@ describe('ERC721A', function () {
 
       it('does not revert for non-receivers', async function () {
         const nonReceiver = this.erc721a;
-        await this.erc721a['mint(address,uint256)'](nonReceiver.address, 1);
+        await this.erc721a.mint(nonReceiver.address, 1, data, false);
         expect(await this.erc721a.ownerOf(0)).to.equal(nonReceiver.address);
       });
 
       it('rejects mints to the zero address', async function () {
-        await expect(this.erc721a['mint(address,uint256)'](ZERO_ADDRESS, 1)).to.be.revertedWith(
+        await expect(this.erc721a.mint(ZERO_ADDRESS, 1, data, false)).to.be.revertedWith(
           'ERC721A: mint to the zero address'
         );
       });
 
       it('requires quantity to be greater than 0', async function () {
-        await expect(this.erc721a['mint(address,uint256)'](this.owner.address, 0)).to.be.revertedWith(
+        await expect(this.erc721a.mint(this.owner.address, 0, data, false)).to.be.revertedWith(
           'ERC721A: quantity must be greater than 0'
         );
       });


### PR DESCRIPTION
Several people have asked me about providing a _mint function that doesn't check for onERC721Received. This PR adds a separate `_mint` function that shares the same logic as `_safeMint`, but removes the `_checkOnERC721Received` requirement.