### PR TITLE
feature: use custom errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npm install --save-dev erc721a
 Once installed, you can use the contracts in the library by importing them:
 
 ```solidity
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import "erc721a/contracts/ERC721A.sol";
 

--- a/contracts/extensions/ERC721AOwnersExplicit.sol
+++ b/contracts/extensions/ERC721AOwnersExplicit.sol
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MIT
 // Creator: Chiru Labs
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import '../ERC721A.sol';
+
+error AllOwnershipsHaveBeenSet();
+error QuantityMustBeNonZero();
+error NoTokensMintedYet();
 
 abstract contract ERC721AOwnersExplicit is ERC721A {
     uint256 public nextOwnerToExplicitlySet;
@@ -12,10 +16,10 @@ abstract contract ERC721AOwnersExplicit is ERC721A {
      * @dev Explicitly set `owners` to eliminate loops in future calls of ownerOf().
      */
     function _setOwnersExplicit(uint256 quantity) internal {
-        require(quantity != 0, 'quantity must be nonzero');
-        require(currentIndex != 0, 'no tokens minted yet');
+        if (quantity == 0) revert QuantityMustBeNonZero();
+        if (currentIndex == 0) revert NoTokensMintedYet();
         uint256 _nextOwnerToExplicitlySet = nextOwnerToExplicitlySet;
-        require(_nextOwnerToExplicitlySet < currentIndex, 'all ownerships have been set');
+        if (_nextOwnerToExplicitlySet >= currentIndex) revert AllOwnershipsHaveBeenSet();
 
         // Index underflow is impossible.
         // Counter or index overflow is incredibly unrealistic.

--- a/contracts/mocks/ERC721AExplicitOwnershipMock.sol
+++ b/contracts/mocks/ERC721AExplicitOwnershipMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Creators: Chiru Labs
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import '../extensions/ERC721AOwnersExplicit.sol';
 

--- a/contracts/mocks/ERC721AGasReporterMock.sol
+++ b/contracts/mocks/ERC721AGasReporterMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Creators: Chiru Labs
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import '../ERC721A.sol';
 

--- a/contracts/mocks/ERC721AMock.sol
+++ b/contracts/mocks/ERC721AMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Creators: Chiru Labs
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import '../ERC721A.sol';
 

--- a/contracts/mocks/ERC721ReceiverMock.sol
+++ b/contracts/mocks/ERC721ReceiverMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Creators: Chiru Labs
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import '@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol';
 

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -55,9 +55,7 @@ describe('ERC721A', function () {
       });
 
       it('throws an exception for the 0 address', async function () {
-        await expect(this.erc721a.balanceOf(ZERO_ADDRESS)).to.be.revertedWith(
-          'ERC721A: balance query for the zero address'
-        );
+        await expect(this.erc721a.balanceOf(ZERO_ADDRESS)).to.be.revertedWith('BalanceQueryForZeroAddress');
       });
     });
 
@@ -78,7 +76,7 @@ describe('ERC721A', function () {
       });
 
       it('reverts for an invalid token', async function () {
-        await expect(this.erc721a.ownerOf(10)).to.be.revertedWith('ERC721A: owner query for nonexistent token');
+        await expect(this.erc721a.ownerOf(10)).to.be.revertedWith('OwnerQueryForNonexistentToken');
       });
     });
 
@@ -94,18 +92,18 @@ describe('ERC721A', function () {
 
       it('rejects an invalid token owner', async function () {
         await expect(this.erc721a.connect(this.addr1).approve(this.addr2.address, tokenId2)).to.be.revertedWith(
-          'ERC721A: approval to current owner'
+          'ApprovalToCurrentOwner'
         );
       });
 
       it('rejects an unapproved caller', async function () {
         await expect(this.erc721a.approve(this.addr2.address, tokenId)).to.be.revertedWith(
-          'ERC721A: approve caller is not owner nor approved for all'
+          'ApprovalCallerNotOwnerNorApproved'
         );
       });
 
       it('does not get approved for invalid tokens', async function () {
-        await expect(this.erc721a.getApproved(10)).to.be.revertedWith('ERC721A: approved query for nonexistent token');
+        await expect(this.erc721a.getApproved(10)).to.be.revertedWith('ApprovalQueryForNonexistentToken');
       });
     });
 
@@ -120,7 +118,7 @@ describe('ERC721A', function () {
 
       it('sets rejects approvals for non msg senders', async function () {
         await expect(this.erc721a.connect(this.addr1).setApprovalForAll(this.addr1.address, true)).to.be.revertedWith(
-          'ERC721A: approve to caller'
+          'ApproveToCaller'
         );
       });
     });
@@ -172,21 +170,21 @@ describe('ERC721A', function () {
         it('rejects unapproved transfer', async function () {
           await expect(
             this.erc721a.connect(this.addr1)[transferFn](this.addr2.address, this.addr1.address, tokenId)
-          ).to.be.revertedWith('ERC721A: transfer caller is not owner nor approved');
+          ).to.be.revertedWith('TransferCallerNotOwnerNorApproved');
         });
 
         it('rejects transfer from incorrect owner', async function () {
           await this.erc721a.connect(this.addr2).setApprovalForAll(this.addr1.address, true);
           await expect(
             this.erc721a.connect(this.addr1)[transferFn](this.addr3.address, this.addr1.address, tokenId)
-          ).to.be.revertedWith('ERC721A: transfer from incorrect owner');
+          ).to.be.revertedWith('TransferFromIncorrectOwner');
         });
 
         it('rejects transfer to zero address', async function () {
           await this.erc721a.connect(this.addr2).setApprovalForAll(this.addr1.address, true);
           await expect(
             this.erc721a.connect(this.addr1)[transferFn](this.addr2.address, ZERO_ADDRESS, tokenId)
-          ).to.be.revertedWith('ERC721A: transfer to the zero address');
+          ).to.be.revertedWith('TransferToZeroAddress');
         });
       };
 
@@ -250,20 +248,20 @@ describe('ERC721A', function () {
 
       it('rejects mints to the zero address', async function () {
         await expect(this.erc721a['safeMint(address,uint256)'](ZERO_ADDRESS, 1)).to.be.revertedWith(
-          'ERC721A: mint to the zero address'
+          'MintToZeroAddress'
         );
       });
 
       it('requires quantity to be greater than 0', async function () {
         await expect(this.erc721a['safeMint(address,uint256)'](this.owner.address, 0)).to.be.revertedWith(
-          'ERC721A: quantity must be greater than 0'
+          'MintZeroQuantity'
         );
       });
 
       it('reverts for non-receivers', async function () {
         const nonReceiver = this.erc721a;
         await expect(this.erc721a['safeMint(address,uint256)'](nonReceiver.address, 1)).to.be.revertedWith(
-          'ERC721A: transfer to non ERC721Receiver implementer'
+          'TransferToNonERC721ReceiverImplementer'
         );
       });
     });
@@ -274,7 +272,7 @@ describe('ERC721A', function () {
       it('successfully mints a single token', async function () {
         const mintTx = await this.erc721a.mint(this.receiver.address, 1, data, false);
         await expect(mintTx).to.emit(this.erc721a, 'Transfer').withArgs(ZERO_ADDRESS, this.receiver.address, 0);
-        await expect(mintTx).to.not.emit(this.receiver, 'Received')
+        await expect(mintTx).to.not.emit(this.receiver, 'Received');
         expect(await this.erc721a.ownerOf(0)).to.equal(this.receiver.address);
       });
 
@@ -282,7 +280,7 @@ describe('ERC721A', function () {
         const mintTx = await this.erc721a.mint(this.receiver.address, 5, data, false);
         for (let tokenId = 0; tokenId < 5; tokenId++) {
           await expect(mintTx).to.emit(this.erc721a, 'Transfer').withArgs(ZERO_ADDRESS, this.receiver.address, tokenId);
-          await expect(mintTx).to.not.emit(this.receiver, 'Received')
+          await expect(mintTx).to.not.emit(this.receiver, 'Received');
           expect(await this.erc721a.ownerOf(tokenId)).to.equal(this.receiver.address);
         }
       });
@@ -294,15 +292,11 @@ describe('ERC721A', function () {
       });
 
       it('rejects mints to the zero address', async function () {
-        await expect(this.erc721a.mint(ZERO_ADDRESS, 1, data, false)).to.be.revertedWith(
-          'ERC721A: mint to the zero address'
-        );
+        await expect(this.erc721a.mint(ZERO_ADDRESS, 1, data, false)).to.be.revertedWith('MintToZeroAddress');
       });
 
       it('requires quantity to be greater than 0', async function () {
-        await expect(this.erc721a.mint(this.owner.address, 0, data, false)).to.be.revertedWith(
-          'ERC721A: quantity must be greater than 0'
-        );
+        await expect(this.erc721a.mint(this.owner.address, 0, data, false)).to.be.revertedWith('MintZeroQuantity');
       });
     });
   });

--- a/test/extensions/ERC721AOwnersExplicit.test.js
+++ b/test/extensions/ERC721AOwnersExplicit.test.js
@@ -11,7 +11,7 @@ describe('ERC721AOwnersExplicit', function () {
 
   context('with no minted tokens', async function () {
     it('does not have enough tokens minted', async function () {
-      await expect(this.token.setOwnersExplicit(1)).to.be.revertedWith('no tokens minted yet');
+      await expect(this.token.setOwnersExplicit(1)).to.be.revertedWith('NoTokensMintedYet');
     });
   });
 
@@ -31,7 +31,7 @@ describe('ERC721AOwnersExplicit', function () {
 
     describe('setOwnersExplicit', async function () {
       it('rejects 0 quantity', async function () {
-        await expect(this.token.setOwnersExplicit(0)).to.be.revertedWith('quantity must be nonzero');
+        await expect(this.token.setOwnersExplicit(0)).to.be.revertedWith('QuantityMustBeNonZero');
       });
 
       it('handles single increment properly', async function () {
@@ -78,7 +78,7 @@ describe('ERC721AOwnersExplicit', function () {
 
       it('rejects after all ownerships have been set', async function () {
         await this.token.setOwnersExplicit(6);
-        await expect(this.token.setOwnersExplicit(1)).to.be.revertedWith('all ownerships have been set');
+        await expect(this.token.setOwnersExplicit(1)).to.be.revertedWith('AllOwnershipsHaveBeenSet');
       });
     });
   });


### PR DESCRIPTION
## Context

Starting from Solidity [v0.8.4](https://blog.soliditylang.org/2021/04/21/custom-errors/), there is a convenient and gas-efficient way to explain to users why an operation failed through the use of custom errors. This way is less expensive, especially when it comes to deploying cost than passing a string to require or assert.

## Gas comparison 

**Before**
<img width="882" alt="before" src="https://user-images.githubusercontent.com/33158502/152606926-27baaf11-fcd6-4f85-ae2b-90c1e0c1bbfd.png">

**After**
<img width="881" alt="after" src="https://user-images.githubusercontent.com/33158502/152607898-3310e84c-54bd-4893-a006-15680626ed89.png">

## Result

As you can observe, the deployment cost is highly reduced for the mocked contracts (almost 20%).

## Tradeoff

This improvement requires a bump to 0.8.**4**.  I am personally convinced this is worth it and the accessibility issue caused by the bump is acceptable due to the fact the bump is minor.
