### PR TITLE
add _unsafeMint function

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -305,6 +305,11 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
      * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called for each safe transfer.
      * - `quantity` must be greater than 0.
      *
+     * Requirements:
+     *
+     * - `to` cannot be the zero address.
+     * - `quantity` must be greater than 0.
+     *
      * Emits a {Transfer} event.
      */
     function _safeMint(
@@ -315,6 +320,31 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
         _mint(to, quantity, _data, true);
     }
 
+    function _unsafeMint(address to, uint256 quantity) internal {
+        _unsafeMint(to, quantity, '');
+    }
+
+    /**
+     * @dev afely mints `quantity` tokens and transfers them to `to`.
+     *
+     * @dev Unsafe: doesn't execute `onERC721Received` on the receiver.
+     *      Prefer the use of `saveMint` instead of `mint` if you don't know the defrence.
+     *
+     * Requirements:
+     *
+     * - `to` cannot be the zero address.
+     * - `quantity` must be greater than 0.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _unsafeMint(
+        address to,
+        uint256 quantity,
+        bytes memory _data
+    ) internal {
+        _mint(to, quantity, _data, false);
+    }
+
     /**
      * @dev Mints `quantity` tokens and transfers them to `to`.
      *
@@ -322,6 +352,8 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
      *
      * - `to` cannot be the zero address.
      * - `quantity` must be greater than 0.
+     * - `_data` additional info to be used in `onERC721Received` function.
+     * - `safe` indicates whether to execute `onERC721Received` on the receiver or not.
      *
      * Emits a {Transfer} event.
      */

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -325,7 +325,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
     }
 
     /**
-     * @dev afely mints `quantity` tokens and transfers them to `to`.
+     * @dev Unsafely mints `quantity` tokens and transfers them to `to`.
      *
      * @dev Unsafe: doesn't execute `onERC721Received` on the receiver.
      *      Prefer the use of `saveMint` instead of `mint` if you don't know the defrence.

--- a/contracts/mocks/ERC721AMock.sol
+++ b/contracts/mocks/ERC721AMock.sol
@@ -32,6 +32,10 @@ contract ERC721AMock is ERC721A {
         _safeMint(to, quantity, _data);
     }
 
+    function unsafeMint(address to, uint256 quantity) public {
+        _unsafeMint(to, quantity);
+    }
+
     function mint(
         address to,
         uint256 quantity,


### PR DESCRIPTION
For easier use so that we do not have to fill all 4 parameters.
I think with that way, mocking and testing `_mint` function is redundant, let me know if it did, so I remove related tests.  

Also, I think `_mint` function should be `private` instead of `internal` cause with `_safeMint` and `_unsafeMint` functions there's no additional need for developers to use this method directly. I wait to hear other's opinion about this.

I will add testGas tests after I figure out whether we should make `_mint` function internal or make it private.  Also, there are some bugs in [test/GasUsage.test.js](https://github.com/chiru-labs/ERC721A/blob/7b3038e294253e75b4878a530c8c9a8ec293f0a8/test/GasUsage.test.js) context names, I'm not sure to fix them in this PR or make another.