### PR TITLE
Optimize approval check

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -381,7 +381,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
 
         bool isApprovedOrOwner = (_msgSender() == prevOwnership.addr ||
             isApprovedForAll(prevOwnership.addr, _msgSender()) ||
-            _tokenApprovals[tokenId] == _msgSender());
+            getApproved(tokenId) == _msgSender());
 
         if (!isApprovedOrOwner) revert TransferCallerNotOwnerNorApproved();
         if (prevOwnership.addr != from) revert TransferFromIncorrectOwner();

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -380,8 +380,8 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
         TokenOwnership memory prevOwnership = ownershipOf(tokenId);
 
         bool isApprovedOrOwner = (_msgSender() == prevOwnership.addr ||
-            getApproved(tokenId) == _msgSender() ||
-            isApprovedForAll(prevOwnership.addr, _msgSender()));
+            isApprovedForAll(prevOwnership.addr, _msgSender()) ||
+            _tokenApprovals[tokenId] == _msgSender());
 
         if (!isApprovedOrOwner) revert TransferCallerNotOwnerNorApproved();
         if (prevOwnership.addr != from) revert TransferFromIncorrectOwner();


### PR DESCRIPTION
**Rationale**

`setApprovalForAll` is typically used more often than `approve`. (e.g. on marketplaces).

In practice, `isApprovedForAll` is more likely to return true compared to  `getApproved`.

Moving the `isApprovedForAll` check before `getApproved` can save some gas via boolean short circuiting.

