### PR TITLE
Add aux to AddressData

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -19,6 +19,7 @@ error ApprovalToCurrentOwner();
 error BalanceQueryForZeroAddress();
 error MintedQueryForZeroAddress();
 error BurnedQueryForZeroAddress();
+error AuxQueryForZeroAddress();
 error MintToZeroAddress();
 error MintZeroQuantity();
 error OwnerIndexOutOfBounds();
@@ -62,6 +63,10 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
         uint64 numberMinted;
         // Keeps track of burn count with minimal overhead for tokenomics.
         uint64 numberBurned;
+        // For miscellaneous variable(s) pertaining to the address
+        // (e.g. number of whitelist mint slots used). 
+        // If there are multiple variables, please pack them into a uint64.
+        uint64 aux;
     }
 
     // The tokenId of the next token to be minted.
@@ -131,6 +136,16 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
     function _numberBurned(address owner) internal view returns (uint256) {
         if (owner == address(0)) revert BurnedQueryForZeroAddress();
         return uint256(_addressData[owner].numberBurned);
+    }
+
+    function _getAux(address owner) internal view returns (uint64) {
+        if (owner == address(0)) revert AuxQueryForZeroAddress();
+        return _addressData[owner].aux;
+    }
+
+    function _setAux(address owner, uint64 aux) internal {
+        if (owner == address(0)) revert AuxQueryForZeroAddress();
+        _addressData[owner].aux = aux;
     }
 
     /**

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -33,7 +33,7 @@ error URIQueryForNonexistentToken();
 
 /**
  * @dev Implementation of https://eips.ethereum.org/EIPS/eip-721[ERC721] Non-Fungible Token Standard, including
- * the Metadata and Enumerable extension. Built to optimize for lower gas during batch mints.
+ * the Metadata extension. Built to optimize for lower gas during batch mints.
  *
  * Assumes serials are sequentially minted starting at 0 (e.g. 0, 1, 2, 3..).
  *
@@ -128,21 +128,34 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
         return uint256(_addressData[owner].balance);
     }
 
+    /**
+     * Returns the number of tokens minted by `owner`.
+     */
     function _numberMinted(address owner) internal view returns (uint256) {
         if (owner == address(0)) revert MintedQueryForZeroAddress();
         return uint256(_addressData[owner].numberMinted);
     }
 
+    /**
+     * Returns the number of tokens burned by or on behalf of `owner`.
+     */
     function _numberBurned(address owner) internal view returns (uint256) {
         if (owner == address(0)) revert BurnedQueryForZeroAddress();
         return uint256(_addressData[owner].numberBurned);
     }
 
+    /**
+     * Returns the auxillary data for `owner`. (e.g. number of whitelist mint slots used).
+     */
     function _getAux(address owner) internal view returns (uint64) {
         if (owner == address(0)) revert AuxQueryForZeroAddress();
         return _addressData[owner].aux;
     }
 
+    /**
+     * Sets the auxillary data for `owner`. (e.g. number of whitelist mint slots used).
+     * If there are multiple variables, please pack them into a uint64.
+     */
     function _setAux(address owner, uint64 aux) internal {
         if (owner == address(0)) revert AuxQueryForZeroAddress();
         _addressData[owner].aux = aux;

--- a/contracts/mocks/ERC721AMock.sol
+++ b/contracts/mocks/ERC721AMock.sol
@@ -12,6 +12,14 @@ contract ERC721AMock is ERC721A {
         return _numberMinted(owner);
     }
 
+    function getAux(address owner) public view returns (uint64) {
+        return _getAux(owner);
+    }
+
+    function setAux(address owner, uint64 aux) public {
+        _setAux(owner, aux);
+    }
+
     function baseURI() public view returns (string memory) {
         return _baseURI();
     }

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -68,6 +68,31 @@ describe('ERC721A', function () {
       });
     });
 
+    describe('aux', async function () {
+      it('get and set works correctly', async function () {
+        const uint64Max = '18446744073709551615';
+        expect(await this.erc721a.getAux(this.owner.address)).to.equal('0');
+        await this.erc721a.setAux(this.owner.address, uint64Max);
+        expect(await this.erc721a.getAux(this.owner.address)).to.equal(uint64Max);
+        
+        expect(await this.erc721a.getAux(this.addr1.address)).to.equal('0');
+        await this.erc721a.setAux(this.addr1.address, '1');
+        expect(await this.erc721a.getAux(this.addr1.address)).to.equal('1');
+
+        await this.erc721a.setAux(this.addr3.address, '5');
+        expect(await this.erc721a.getAux(this.addr3.address)).to.equal('5');
+
+        expect(await this.erc721a.getAux(this.addr1.address)).to.equal('1');
+      });
+      
+      it('get and set rejects the zero address', async function () {
+        await expect(this.erc721a.getAux(ZERO_ADDRESS))
+          .to.be.revertedWith('AuxQueryForZeroAddress');
+        await expect(this.erc721a.setAux(ZERO_ADDRESS, '1'))
+          .to.be.revertedWith('AuxQueryForZeroAddress');
+      });
+    });
+
     describe('ownerOf', async function () {
       it('returns the right owner', async function () {
         expect(await this.erc721a.ownerOf(0)).to.equal(this.addr1.address);


### PR DESCRIPTION
After adding the `burn` feature, the `AddressData` struct still has 64 bits of unused space.

**_This is free real estate._** 

This PR adds an `aux` variable for the `AddressData` to let users make full use of the extra space,   
along with the relevant `_getAux` and `_setAux` functions.

This `aux` can be used for storing miscellaneous things like number of whitelist mint slots used.

Deriving contracts can avoid the overhead of an additional expensive SLOAD and SSTORE with this feature.

If there are no likely plans to use the extra 64 bits of space for future features, we can consider this.