### PR TITLE
Overoptimization is the root of all evil

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -64,14 +64,11 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable
         uint64 numberBurned;
     }
 
-    // Compiler will pack the following 
-    // _currentIndex and _burnCounter into a single 256bit word.
-    
     // The tokenId of the next token to be minted.
-    uint128 internal _currentIndex;
+    uint256 internal _currentIndex;
 
     // The number of tokens burned.
-    uint128 internal _burnCounter;
+    uint256 internal _burnCounter;
 
     // Token name
     string private _name;


### PR DESCRIPTION
Remove unneeded "optimization" for `_currentIndex` and `_burnCounter`.

These are only ever accessed at the same time (read: combining them saves gas) in `totalSupply`. 

In all other cases, this "optimization" actually increases costs to access storage for both variables.

Because the "optimization" is bad--it hurts gas where gas matters and it helps gas /only/ where gas does not matter, I have removed it.
    
