### PR TITLE
Mint re-entrancy guard with optimizations.

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -399,7 +399,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
             uint256 end = updatedIndex + quantity;
 
             if (safe && to.isContract()) {
-                while (updatedIndex < end) {
+                while (updatedIndex != end) {
                     emit Transfer(address(0), to, updatedIndex);
                     if (!_checkOnERC721Received(address(0), to, updatedIndex, _data)) {
                         revert TransferToNonERC721ReceiverImplementer();
@@ -409,7 +409,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
                 // Reentrancy protection
                 if (_currentIndex != startTokenId) revert();
             } else {
-                while (updatedIndex < end) {
+                while (updatedIndex != end) {
                     emit Transfer(address(0), to, updatedIndex);
                     updatedIndex++;
                 }    

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -401,17 +401,15 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
             if (safe && to.isContract()) {
                 while (updatedIndex != end) {
                     emit Transfer(address(0), to, updatedIndex);
-                    if (!_checkContractOnERC721Received(address(0), to, updatedIndex, _data)) {
+                    if (!_checkContractOnERC721Received(address(0), to, updatedIndex++, _data)) {
                         revert TransferToNonERC721ReceiverImplementer();
                     }
-                    updatedIndex++;
                 }
                 // Reentrancy protection
                 if (_currentIndex != startTokenId) revert();
             } else {
                 while (updatedIndex != end) {
-                    emit Transfer(address(0), to, updatedIndex);
-                    updatedIndex++;
+                    emit Transfer(address(0), to, updatedIndex++);
                 }    
             }
             _currentIndex = updatedIndex;

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -404,7 +404,8 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
                 }
                 updatedIndex++;
             }
-
+            // Reentrancy protection.
+            if (safe && _currentIndex != startTokenId) revert();
             _currentIndex = updatedIndex;
         }
         _afterTokenTransfers(address(0), to, startTokenId, quantity);

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -399,18 +399,18 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
             uint256 end = updatedIndex + quantity;
 
             if (safe && to.isContract()) {
-                while (updatedIndex != end) {
+                do {
                     emit Transfer(address(0), to, updatedIndex);
                     if (!_checkContractOnERC721Received(address(0), to, updatedIndex++, _data)) {
                         revert TransferToNonERC721ReceiverImplementer();
                     }
-                }
+                } while (updatedIndex != end);
                 // Reentrancy protection
                 if (_currentIndex != startTokenId) revert();
             } else {
-                while (updatedIndex != end) {
+                do {
                     emit Transfer(address(0), to, updatedIndex++);
-                }    
+                } while (updatedIndex != end);
             }
             _currentIndex = updatedIndex;
         }

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -324,7 +324,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
         bytes memory _data
     ) public virtual override {
         _transfer(from, to, tokenId);
-        if (!_checkOnERC721Received(from, to, tokenId, _data)) {
+        if (to.isContract() && !_checkContractOnERC721Received(from, to, tokenId, _data)) {
             revert TransferToNonERC721ReceiverImplementer();
         }
     }
@@ -401,7 +401,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
             if (safe && to.isContract()) {
                 while (updatedIndex != end) {
                     emit Transfer(address(0), to, updatedIndex);
-                    if (!_checkOnERC721Received(address(0), to, updatedIndex, _data)) {
+                    if (!_checkContractOnERC721Received(address(0), to, updatedIndex, _data)) {
                         revert TransferToNonERC721ReceiverImplementer();
                     }
                     updatedIndex++;
@@ -551,7 +551,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
      * @param _data bytes optional data to send along with the call
      * @return bool whether the call correctly returned the expected magic value
      */
-    function _checkOnERC721Received(
+    function _checkContractOnERC721Received(
         address from,
         address to,
         uint256 tokenId,


### PR DESCRIPTION
Ok, so as we know, the `_safeMint` function is **NOT** safe from re-entrancy. #92 

Ideally, most contracts should use `_mint`.

Although we can warn about it in the comments / docs, many devs won't read it and will happily use `_safeMint` as it is. 
For security reasons, I won't cite any examples here. 

Furthermore, the README example shows `_safeMint` being used in an unprotected manner. 

From a usability point of view, I suggest that we make the `_mint` function re-entrancy safe regardless, to be foolproof. 

This will also reduce the cognitive dissonance of `_safeMint` being unsafe, giving a cleaner API design.

The overhead is only 100 gas for an extra warm SLOAD. 
Assuming a function using `_safeMint` costs ~60K gas, this is only 0.2% overhead that can protect against catastrophic consequences. For users who use `_mint`, the gas overhead is as good as none.

To ease the concerns for the increase in gas for `_safeMint`, the function is optimized even further, such that we can save more gas to cover for the overhead.

In practice, implementations that need to use `_safeMint` for some reason can save 2k gas (cold SLOAD) with this functionality, as they don't need to use OpenZepplin's Reentrancy guard. 

**Before:**

```
·------------------------------------------|---------------------------|-------------|
|           Solc version: 0.8.11           ·  Optimizer enabled: true  ·  Runs: 800  ·
···········································|···························|·············|
|  Methods                                                                            
···························|···············|·············|·············|·············|
|  Contract                ·  Method       ·  Min        ·  Max        ·  Avg        ·
···························|···············|·············|·············|·············|
|  ERC721AGasReporterMock  ·  mintOne      ·      56502  ·      90702  ·      57186  ·
···························|···············|·············|·············|·············|
|  ERC721AGasReporterMock  ·  mintTen      ·      74696  ·     108896  ·      75380  ·
···························|···············|·············|·············|·············|
|  ERC721AGasReporterMock  ·  safeMintOne  ·      59256  ·      93456  ·      59940  ·
···························|···············|·············|·············|·············|
|  ERC721AGasReporterMock  ·  safeMintTen  ·      79246  ·     113446  ·      79930  ·
···························|···············|·············|·············|·············|
|  Deployments                             ·                                         ·
···········································|·············|·············|·············|
|  ERC721AGasReporterMock                  ·          -  ·          -  ·    1146497  ·
···········································|·············|·············|·············|
```

**After re-entrancy guard + gas optimizations:**
```
·------------------------------------------|---------------------------|-------------|
|           Solc version: 0.8.11           ·  Optimizer enabled: true  ·  Runs: 800  ·
···········································|···························|·············|
|  Methods                                                                            
···························|···············|·············|·············|·············|
|  Contract                ·  Method       ·  Min        ·  Max        ·  Avg        ·
···························|···············|·············|·············|·············|
|  ERC721AGasReporterMock  ·  mintOne      ·      56462  ·      90662  ·      57146  ·
···························|···············|·············|·············|·············|
|  ERC721AGasReporterMock  ·  mintTen      ·      74116  ·     108316  ·      74800  ·
···························|···············|·············|·············|·············|
|  ERC721AGasReporterMock  ·  safeMintOne  ·      59143  ·      93343  ·      59827  ·
···························|···············|·············|·············|·············|
|  ERC721AGasReporterMock  ·  safeMintTen  ·      76775  ·     110975  ·      77459  ·
···························|···············|·············|·············|·············|
|  Deployments                             ·                                         ·
···········································|·············|·············|·············|
|  ERC721AGasReporterMock                  ·          -  ·          -  ·    1168285  ·
·------------------------------------------|-------------|-------------|-------------|
```

@cygaar @ahbanavi 