### PR TITLE
Removed zero address check on _numberMinted

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -152,7 +152,6 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
      * Returns the number of tokens minted by `owner`.
      */
     function _numberMinted(address owner) internal view returns (uint256) {
-        if (owner == address(0)) revert MintedQueryForZeroAddress();
         return uint256(_addressData[owner].numberMinted);
     }
 

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -17,7 +17,6 @@ error ApprovalQueryForNonexistentToken();
 error ApproveToCaller();
 error ApprovalToCurrentOwner();
 error BalanceQueryForZeroAddress();
-error MintedQueryForZeroAddress();
 error BurnedQueryForZeroAddress();
 error AuxQueryForZeroAddress();
 error MintToZeroAddress();


### PR DESCRIPTION
There is already a zero address check on `mint`, so you can safely check the zero address via this view function - it should always return zero.