### PR TITLE
chore: unify internal function style

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -82,7 +82,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
     string private _symbol;
 
     // Mapping from token ID to ownership details
-    // An empty struct value does not necessarily mean the token is unowned. See ownershipOf implementation for details.
+    // An empty struct value does not necessarily mean the token is unowned. See _ownershipOf implementation for details.
     mapping(uint256 => TokenOwnership) internal _ownerships;
 
     // Mapping owner address to address data
@@ -185,7 +185,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
      * Gas spent here starts off proportional to the maximum mint batch size.
      * It gradually moves to O(1) as tokens get transferred around in the collection over time.
      */
-    function ownershipOf(uint256 tokenId) internal view returns (TokenOwnership memory) {
+    function _ownershipOf(uint256 tokenId) internal view returns (TokenOwnership memory) {
         uint256 curr = tokenId;
 
         unchecked {
@@ -216,7 +216,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
      * @dev See {IERC721-ownerOf}.
      */
     function ownerOf(uint256 tokenId) public view override returns (address) {
-        return ownershipOf(tokenId).addr;
+        return _ownershipOf(tokenId).addr;
     }
 
     /**
@@ -432,7 +432,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
         address to,
         uint256 tokenId
     ) private {
-        TokenOwnership memory prevOwnership = ownershipOf(tokenId);
+        TokenOwnership memory prevOwnership = _ownershipOf(tokenId);
 
         bool isApprovedOrOwner = (_msgSender() == prevOwnership.addr ||
             isApprovedForAll(prevOwnership.addr, _msgSender()) ||
@@ -485,7 +485,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
      * Emits a {Transfer} event.
      */
     function _burn(uint256 tokenId) internal virtual {
-        TokenOwnership memory prevOwnership = ownershipOf(tokenId);
+        TokenOwnership memory prevOwnership = _ownershipOf(tokenId);
 
         _beforeTokenTransfers(prevOwnership.addr, address(0), tokenId, 1);
 

--- a/contracts/extensions/ERC721ABurnable.sol
+++ b/contracts/extensions/ERC721ABurnable.sol
@@ -20,7 +20,7 @@ abstract contract ERC721ABurnable is Context, ERC721A {
      * - The caller must own `tokenId` or be an approved operator.
      */
     function burn(uint256 tokenId) public virtual {
-        TokenOwnership memory prevOwnership = ownershipOf(tokenId);
+        TokenOwnership memory prevOwnership = _ownershipOf(tokenId);
 
         bool isApprovedOrOwner = (_msgSender() == prevOwnership.addr ||
             isApprovedForAll(prevOwnership.addr, _msgSender()) ||

--- a/contracts/extensions/ERC721AOwnersExplicit.sol
+++ b/contracts/extensions/ERC721AOwnersExplicit.sol
@@ -36,7 +36,7 @@ abstract contract ERC721AOwnersExplicit is ERC721A {
 
             for (uint256 i = _nextOwnerToExplicitlySet; i <= endIndex; i++) {
                 if (_ownerships[i].addr == address(0) && !_ownerships[i].burned) {
-                    TokenOwnership memory ownership = ownershipOf(i);
+                    TokenOwnership memory ownership = _ownershipOf(i);
                     _ownerships[i].addr = ownership.addr;
                     _ownerships[i].startTimestamp = ownership.startTimestamp;
                 }


### PR DESCRIPTION
All internal functions are prefixed with `_` except `ownershipOf`. Should be slightly better to have unified style.