### PR TITLE
Add approvalCheck argument in _burn

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -482,8 +482,16 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
      *
      * Emits a {Transfer} event.
      */
-    function _burn(uint256 tokenId) internal virtual {
+    function _burn(uint256 tokenId, bool approvalCheck) internal virtual {
         TokenOwnership memory prevOwnership = _ownershipOf(tokenId);
+
+        if (approvalCheck) {
+            bool isApprovedOrOwner = (_msgSender() == prevOwnership.addr ||
+                isApprovedForAll(prevOwnership.addr, _msgSender()) ||
+                getApproved(tokenId) == _msgSender());
+
+            if (!isApprovedOrOwner) revert TransferCallerNotOwnerNorApproved();
+        }
 
         _beforeTokenTransfers(prevOwnership.addr, address(0), tokenId, 1);
 

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -473,6 +473,13 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
     }
 
     /**
+     * @dev This is equivalent to _burn(tokenId, false)
+     */
+    function _burn(uint256 tokenId) internal virtual {
+        _burn(tokenId, false);
+    }
+
+    /**
      * @dev Destroys `tokenId`.
      * The approval is cleared when the token is burned.
      *

--- a/contracts/extensions/ERC721ABurnable.sol
+++ b/contracts/extensions/ERC721ABurnable.sol
@@ -4,13 +4,12 @@
 pragma solidity ^0.8.4;
 
 import '../ERC721A.sol';
-import '@openzeppelin/contracts/utils/Context.sol';
 
 /**
  * @title ERC721A Burnable Token
  * @dev ERC721A Token that can be irreversibly burned (destroyed).
  */
-abstract contract ERC721ABurnable is Context, ERC721A {
+abstract contract ERC721ABurnable is ERC721A {
 
     /**
      * @dev Burns `tokenId`. See {ERC721A-_burn}.

--- a/contracts/extensions/ERC721ABurnable.sol
+++ b/contracts/extensions/ERC721ABurnable.sol
@@ -20,14 +20,6 @@ abstract contract ERC721ABurnable is Context, ERC721A {
      * - The caller must own `tokenId` or be an approved operator.
      */
     function burn(uint256 tokenId) public virtual {
-        TokenOwnership memory prevOwnership = _ownershipOf(tokenId);
-
-        bool isApprovedOrOwner = (_msgSender() == prevOwnership.addr ||
-            isApprovedForAll(prevOwnership.addr, _msgSender()) ||
-            getApproved(tokenId) == _msgSender());
-
-        if (!isApprovedOrOwner) revert TransferCallerNotOwnerNorApproved();
-
-        _burn(tokenId);
+        _burn(tokenId, true);
     }
 }

--- a/contracts/mocks/ERC721AMock.sol
+++ b/contracts/mocks/ERC721AMock.sol
@@ -52,4 +52,8 @@ contract ERC721AMock is ERC721A {
     ) public {
         _mint(to, quantity, _data, safe);
     }
+
+    function burn(uint256 tokenId, bool approvalCheck) public {
+        _burn(tokenId, approvalCheck);
+    }
 }

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -255,6 +255,20 @@ const createTestSuite = ({ contract, constructorArgs }) =>
             });
           });
         });
+
+        describe('_burn', async function() {
+          beforeEach(function () {
+            this.tokenIdToBurn = this.startTokenId;
+          })
+          it('can burn if checkApproval is false', async function () {
+            await this.erc721a.connect(this.addr2).burn(this.tokenIdToBurn, false);
+            expect(await this.erc721a.exists(this.tokenIdToBurn)).to.be.false;
+          });
+
+          it('revert if checkApproval is true', async function () {
+            await expect(this.erc721a.connect(this.addr2).burn(this.tokenIdToBurn, true)).to.be.revertedWith('TransferCallerNotOwnerNorApproved');
+          });
+        });
       });
 
       context('mint', async function () {

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -259,7 +259,8 @@ const createTestSuite = ({ contract, constructorArgs }) =>
         describe('_burn', async function() {
           beforeEach(function () {
             this.tokenIdToBurn = this.startTokenId;
-          })
+          });
+
           it('can burn if approvalCheck is false', async function () {
             await this.erc721a.connect(this.addr2).burn(this.tokenIdToBurn, false);
             expect(await this.erc721a.exists(this.tokenIdToBurn)).to.be.false;
@@ -268,7 +269,7 @@ const createTestSuite = ({ contract, constructorArgs }) =>
           it('revert if approvalCheck is true', async function () {
             await expect(
               this.erc721a.connect(this.addr2).burn(this.tokenIdToBurn, true)
-              ).to.be.revertedWith('TransferCallerNotOwnerNorApproved');
+            ).to.be.revertedWith('TransferCallerNotOwnerNorApproved');
           });
         });
       });

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -260,12 +260,12 @@ const createTestSuite = ({ contract, constructorArgs }) =>
           beforeEach(function () {
             this.tokenIdToBurn = this.startTokenId;
           })
-          it('can burn if checkApproval is false', async function () {
+          it('can burn if approvalCheck is false', async function () {
             await this.erc721a.connect(this.addr2).burn(this.tokenIdToBurn, false);
             expect(await this.erc721a.exists(this.tokenIdToBurn)).to.be.false;
           });
 
-          it('revert if checkApproval is true', async function () {
+          it('revert if approvalCheck is true', async function () {
             await expect(this.erc721a.connect(this.addr2).burn(this.tokenIdToBurn, true)).to.be.revertedWith('TransferCallerNotOwnerNorApproved');
           });
         });

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -266,7 +266,9 @@ const createTestSuite = ({ contract, constructorArgs }) =>
           });
 
           it('revert if approvalCheck is true', async function () {
-            await expect(this.erc721a.connect(this.addr2).burn(this.tokenIdToBurn, true)).to.be.revertedWith('TransferCallerNotOwnerNorApproved');
+            await expect(
+              this.erc721a.connect(this.addr2).burn(this.tokenIdToBurn, true)
+              ).to.be.revertedWith('TransferCallerNotOwnerNorApproved');
           });
         });
       });


### PR DESCRIPTION
Fixes #164

~⚠️ This PR is not backwards compatible as it is. We need to add a wrapper for `_burn` for backward compatibility.~
The `_burn` wrapper added.