### PR TITLE
Add Komorebi No Sekai Project

### DIFF
--- a/projects.md
+++ b/projects.md
@@ -40,3 +40,4 @@ Here are a list of projects that have or will be implementing ERC721A as part of
 - [Antonym](https://www.antonymnft.com/) | [Etherscan](https://etherscan.io/address/0x7e3Ef31186D1BEc0D3f35aD701D065743B84C790) | [Twitter](https://twitter.com/AntonymNFT) | [Instagram](https://www.instagram.com/antonym.eth/) | [OpenSea](https://opensea.io/collection/antonymgenesis)
 - [Human Divergence](https://www.humandivergence.com) | Etherscan | [Twitter](https://twitter.com/humandivergence)
 - [Jokers by SLAM](https://slamjokers.com/) | [Etherscan](https://etherscan.io/address/0xe52f3274779d59e98d5876cf24d263cdf1e5c290) | [Twitter](https://twitter.com/jokersbyslam) | [OpenSea](https://opensea.io/collection/slamjokers)
+- [Komorebi No Sekai](https://komorebinosekai.com/) | [Etherscan](https://etherscan.io/address/0x675cddac819d41c37331644047508822d764abed) | [Twitter](https://twitter.com/KomorebiNoSekai) | [OpenSea](https://opensea.io/collection/komorebi-no-sekai)


### PR DESCRIPTION
## Description
Based on `ERC721A` from `Azuki` team, we implemented custom and unique features in our smart contract. We use Chainlink VRF to randomly select a winner on-chain that will receive a set of predefined NFTs. Holders of our KNS NFTs will be able to participate actively to the creation of the manga. Hence the community will have the opportunity to collaborate directly with the artist and the team. In addition, each holder will be assigned to a side: Furaribi or Naito Raito. The side can be used later in the roadmap.

## Special thanks
Huge props to Azuki for the addition of `ERC721A` to the Ethereum NFT ecosystem.

https://hackmd.io/@0xmanga/kns-contract