### PR TITLE
Minor optimization tricks

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -454,7 +454,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
             if (_ownerships[nextTokenId].addr == address(0)) {
                 // This will suffice for checking _exists(nextTokenId),
                 // as a burned slot cannot contain the zero address.
-                if (nextTokenId < _currentIndex) {
+                if (nextTokenId != _currentIndex) {
                     _ownerships[nextTokenId].addr = prevOwnership.addr;
                     _ownerships[nextTokenId].startTimestamp = prevOwnership.startTimestamp;
                 }
@@ -516,7 +516,7 @@ contract ERC721A is Context, ERC165, IERC721, IERC721Metadata {
             if (_ownerships[nextTokenId].addr == address(0)) {
                 // This will suffice for checking _exists(nextTokenId),
                 // as a burned slot cannot contain the zero address.
-                if (nextTokenId < _currentIndex) {
+                if (nextTokenId != _currentIndex) {
                     _ownerships[nextTokenId].addr = prevOwnership.addr;
                     _ownerships[nextTokenId].startTimestamp = prevOwnership.startTimestamp;
                 }


### PR DESCRIPTION
**Just some minor optimizoor tricks**

- Change `<` to `!=`.  
As `tokenId < _currentIndex` (checked in `_ownershipOf`), 
`tokenId + 1 < _currentIndex` is equivalent to `tokenId + 1 != _currentIndex`.

- Use `storage` pointers wherever it somehow reduces gas.   
This doesn't always work, and the gas savings may vary.   
You will need to profile the before and after.

- Cache the `prevOwnership.addr`.
Somehow the compiler will need to unpack it every time. 

**⛽ Gas Reports**

<details>
  <summary>Before</summary>
  
  ```
·---------------------------------------------------------------|---------------------------|-------------|-----------------------------·
|                     Solc version: 0.8.11                      ·  Optimizer enabled: true  ·  Runs: 800  ·  Block limit: 30000000 gas  │
································································|···························|·············|······························
|  Methods                                                                                                                              │
··········································|·····················|·············|·············|·············|···············|··············
|  Contract                               ·  Method             ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableMock                    ·  approve            ·      30839  ·      50979  ·      40909  ·            2  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableMock                    ·  burn               ·      48419  ·     114911  ·      95133  ·           25  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableMock                    ·  safeMint           ·          -  ·          -  ·     111170  ·           15  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableMock                    ·  setApprovalForAll  ·      26277  ·      46189  ·      36233  ·            2  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableMock                    ·  transferFrom       ·      86680  ·      92867  ·      89774  ·            2  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableOwnersExplicitMock      ·  burn               ·      65507  ·      88298  ·      76903  ·            2  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableOwnersExplicitMock      ·  safeMint           ·      78346  ·      93494  ·      84054  ·            3  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableOwnersExplicitMock      ·  setOwnersExplicit  ·          -  ·          -  ·      81199  ·            1  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableStartTokenIdMock        ·  approve            ·      30851  ·      50991  ·      40921  ·            2  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableStartTokenIdMock        ·  burn               ·      48431  ·     112544  ·      92855  ·           26  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableStartTokenIdMock        ·  safeMint           ·          -  ·          -  ·      94048  ·           15  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableStartTokenIdMock        ·  setApprovalForAll  ·      26255  ·      46167  ·      36211  ·            2  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableStartTokenIdMock        ·  transferFrom       ·      86692  ·      90501  ·      88597  ·            2  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock                 ·  mintOne            ·      56462  ·      90662  ·      57146  ·           50  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock                 ·  mintTen            ·      74116  ·     108316  ·      74800  ·           50  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock                 ·  safeMintOne        ·      59143  ·      93343  ·      59827  ·           50  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock                 ·  safeMintTen        ·      76775  ·     110975  ·      77459  ·           50  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AMock                            ·  approve            ·          -  ·          -  ·      50911  ·            1  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AMock                            ·  burn               ·          -  ·          -  ·      65644  ·            1  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AMock                            ·  mint               ·      91770  ·      99626  ·      97531  ·           15  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AMock                            ·  safeMint           ·      78336  ·     123091  ·      88107  ·          116  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AMock                            ·  safeTransferFrom   ·          -  ·          -  ·      93725  ·            9  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AMock                            ·  setApprovalForAll  ·      46185  ·      46197  ·      46196  ·           17  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AMock                            ·  setAux             ·      27122  ·      44306  ·      32850  ·            3  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AMock                            ·  transferFrom       ·      86690  ·      86702  ·      86699  ·            7  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AOwnersExplicitMock              ·  safeMint           ·      78346  ·      93494  ·      84054  ·           21  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AOwnersExplicitMock              ·  setOwnersExplicit  ·      48337  ·     124293  ·      84934  ·            8  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AOwnersExplicitStartTokenIdMock  ·  safeMint           ·      76372  ·      80300  ·      78332  ·           21  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AOwnersExplicitStartTokenIdMock  ·  setOwnersExplicit  ·      48346  ·     124404  ·      84999  ·            8  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock                ·  approve            ·          -  ·          -  ·      50957  ·            1  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock                ·  burn               ·          -  ·          -  ·      65690  ·            1  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock                ·  mint               ·      74670  ·      82526  ·      80431  ·           15  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock                ·  safeMint           ·      76384  ·     106003  ·      81032  ·          116  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock                ·  safeTransferFrom   ·          -  ·          -  ·      93759  ·            9  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock                ·  setApprovalForAll  ·          -  ·          -  ·      46197  ·           17  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock                ·  setAux             ·      27122  ·      44306  ·      32850  ·            3  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock                ·  transferFrom       ·          -  ·          -  ·      86736  ·            7  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  Deployments                                                  ·                                         ·  % of limit   ·             │
································································|·············|·············|·············|···············|··············
|  ERC721ABurnableMock                                          ·          -  ·          -  ·    1319357  ·        4.4 %  ·          -  │
································································|·············|·············|·············|···············|··············
|  ERC721ABurnableOwnersExplicitMock                            ·          -  ·          -  ·    1398770  ·        4.7 %  ·          -  │
································································|·············|·············|·············|···············|··············
|  ERC721ABurnableStartTokenIdMock                              ·          -  ·          -  ·    1387446  ·        4.6 %  ·          -  │
································································|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock                                       ·          -  ·          -  ·    1170730  ·        3.9 %  ·          -  │
································································|·············|·············|·············|···············|··············
|  ERC721AMock                                                  ·          -  ·          -  ·    1441842  ·        4.8 %  ·          -  │
································································|·············|·············|·············|···············|··············
|  ERC721AOwnersExplicitMock                                    ·          -  ·          -  ·    1255001  ·        4.2 %  ·          -  │
································································|·············|·············|·············|···············|··············
|  ERC721AOwnersExplicitStartTokenIdMock                        ·          -  ·          -  ·    1329548  ·        4.4 %  ·          -  │
································································|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock                                      ·          -  ·          -  ·    1506488  ·          5 %  ·          -  │
································································|·············|·············|·············|···············|··············
|  ERC721ReceiverMock                                           ·          -  ·          -  ·     207526  ·        0.7 %  ·          -  │
·---------------------------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```

</details>

<details>
  <summary>After</summary>
  
  ```
·---------------------------------------------------------------|---------------------------|-------------|-----------------------------·
|                     Solc version: 0.8.11                      ·  Optimizer enabled: true  ·  Runs: 800  ·  Block limit: 30000000 gas  │
································································|···························|·············|······························
|  Methods                                                                                                                              │
··········································|·····················|·············|·············|·············|···············|··············
|  Contract                               ·  Method             ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableMock                    ·  approve            ·      30839  ·      50979  ·      40909  ·            2  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableMock                    ·  burn               ·      48116  ·     114509  ·      94742  ·           25  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableMock                    ·  safeMint           ·          -  ·          -  ·     111170  ·           15  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableMock                    ·  setApprovalForAll  ·      26277  ·      46189  ·      36233  ·            2  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableMock                    ·  transferFrom       ·      86552  ·      92838  ·      89695  ·            2  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableOwnersExplicitMock      ·  burn               ·      65204  ·      87896  ·      76550  ·            2  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableOwnersExplicitMock      ·  safeMint           ·      78346  ·      93494  ·      84054  ·            3  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableOwnersExplicitMock      ·  setOwnersExplicit  ·          -  ·          -  ·      81199  ·            1  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableStartTokenIdMock        ·  approve            ·      30851  ·      50991  ·      40921  ·            2  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableStartTokenIdMock        ·  burn               ·      48128  ·     112142  ·      92464  ·           26  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableStartTokenIdMock        ·  safeMint           ·          -  ·          -  ·      94048  ·           15  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableStartTokenIdMock        ·  setApprovalForAll  ·      26255  ·      46167  ·      36211  ·            2  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721ABurnableStartTokenIdMock        ·  transferFrom       ·      86564  ·      90472  ·      88518  ·            2  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock                 ·  mintOne            ·      56462  ·      90662  ·      57146  ·           50  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock                 ·  mintTen            ·      74116  ·     108316  ·      74800  ·           50  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock                 ·  safeMintOne        ·      59143  ·      93343  ·      59827  ·           50  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock                 ·  safeMintTen        ·      76775  ·     110975  ·      77459  ·           50  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AMock                            ·  approve            ·          -  ·          -  ·      50911  ·            1  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AMock                            ·  burn               ·          -  ·          -  ·      65365  ·            1  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AMock                            ·  mint               ·      91770  ·      99626  ·      97531  ·           15  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AMock                            ·  safeMint           ·      78336  ·     123091  ·      88107  ·          116  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AMock                            ·  safeTransferFrom   ·          -  ·          -  ·      93597  ·            9  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AMock                            ·  setApprovalForAll  ·      46185  ·      46197  ·      46196  ·           17  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AMock                            ·  setAux             ·      27122  ·      44306  ·      32850  ·            3  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AMock                            ·  transferFrom       ·      86562  ·      86574  ·      86571  ·            7  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AOwnersExplicitMock              ·  safeMint           ·      78346  ·      93494  ·      84054  ·           21  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AOwnersExplicitMock              ·  setOwnersExplicit  ·      48337  ·     124293  ·      84934  ·            8  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AOwnersExplicitStartTokenIdMock  ·  safeMint           ·      76372  ·      80300  ·      78332  ·           21  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AOwnersExplicitStartTokenIdMock  ·  setOwnersExplicit  ·      48346  ·     124404  ·      84999  ·            8  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock                ·  approve            ·          -  ·          -  ·      50957  ·            1  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock                ·  burn               ·          -  ·          -  ·      65411  ·            1  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock                ·  mint               ·      74670  ·      82526  ·      80431  ·           15  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock                ·  safeMint           ·      76384  ·     106003  ·      81032  ·          116  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock                ·  safeTransferFrom   ·          -  ·          -  ·      93631  ·            9  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock                ·  setApprovalForAll  ·          -  ·          -  ·      46197  ·           17  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock                ·  setAux             ·      27122  ·      44306  ·      32850  ·            3  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock                ·  transferFrom       ·          -  ·          -  ·      86608  ·            7  ·          -  │
··········································|·····················|·············|·············|·············|···············|··············
|  Deployments                                                  ·                                         ·  % of limit   ·             │
································································|·············|·············|·············|···············|··············
|  ERC721ABurnableMock                                          ·          -  ·          -  ·    1300072  ·        4.3 %  ·          -  │
································································|·············|·············|·············|···············|··············
|  ERC721ABurnableOwnersExplicitMock                            ·          -  ·          -  ·    1379490  ·        4.6 %  ·          -  │
································································|·············|·············|·············|···············|··············
|  ERC721ABurnableStartTokenIdMock                              ·          -  ·          -  ·    1368173  ·        4.6 %  ·          -  │
································································|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock                                       ·          -  ·          -  ·    1162575  ·        3.9 %  ·          -  │
································································|·············|·············|·············|···············|··············
|  ERC721AMock                                                  ·          -  ·          -  ·    1422526  ·        4.7 %  ·          -  │
································································|·············|·············|·············|···············|··············
|  ERC721AOwnersExplicitMock                                    ·          -  ·          -  ·    1246823  ·        4.2 %  ·          -  │
································································|·············|·············|·············|···············|··············
|  ERC721AOwnersExplicitStartTokenIdMock                        ·          -  ·          -  ·    1321369  ·        4.4 %  ·          -  │
································································|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock                                      ·          -  ·          -  ·    1487195  ·          5 %  ·          -  │
································································|·············|·············|·············|···············|··············
|  ERC721ReceiverMock                                           ·          -  ·          -  ·     207526  ·        0.7 %  ·          -  │
·---------------------------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```

</details>

