### PR TITLE
Fixing erc721a-owners-explicit.md link on tips page

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -36,7 +36,7 @@ To prevent overly expensive transfer fees for tokens that are minted in large ba
 
 - Break up excessively large batches into mini batches internally when minting. 
 
-- Look into [`ERC721AOwnersExplicit`](erc271a-owners-explicit.md). 
+- Look into [`ERC721AOwnersExplicit`](erc721a-owners-explicit.md). 
 
 ## Efficient Tokenomics
 


### PR DESCRIPTION
Fixing link to `erc721a-owners-explicit.md`

Currently is a 404 due to typo. 