### PR TITLE
CI: ignore docs/ and .md files

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -3,8 +3,14 @@ name: ERC721A CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
 
 jobs:
   run-tests:


### PR DESCRIPTION
IMHO, running npm tests for changes in `.md` files is redundant.  
What do you think?