### PR TITLE
Make tests compatible with upgradables

### DIFF
--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -1,3 +1,4 @@
+const { deployContract } = require('./helpers.js');
 const { expect } = require('chai');
 const { constants } = require('@openzeppelin/test-helpers');
 const { ZERO_ADDRESS } = constants;
@@ -9,13 +10,8 @@ const createTestSuite = ({ contract, constructorArgs }) =>
   function () {
     context(`${contract}`, function () {
       beforeEach(async function () {
-        this.ERC721A = await ethers.getContractFactory(contract);
-
-        this.ERC721Receiver = await ethers.getContractFactory('ERC721ReceiverMock');
-        this.erc721a = await this.ERC721A.deploy(...constructorArgs);
-
-        await this.erc721a.deployed();
-
+        this.erc721a = await deployContract(contract, constructorArgs);
+        this.receiver = await deployContract('ERC721ReceiverMock', [RECEIVER_MAGIC_VALUE]);
         this.startTokenId = this.erc721a.startTokenId ? (await this.erc721a.startTokenId()).toNumber() : 0;
       });
 
@@ -167,7 +163,6 @@ const createTestSuite = ({ contract, constructorArgs }) =>
 
               const sender = this.addr2;
               this.from = sender.address;
-              this.receiver = await this.ERC721Receiver.deploy(RECEIVER_MAGIC_VALUE);
               this.to = this.receiver.address;
               await this.erc721a.connect(sender).setApprovalForAll(this.to, true);
               this.transferTx = await this.erc721a.connect(sender)[transferFn](this.from, this.to, this.tokenId);
@@ -275,7 +270,6 @@ const createTestSuite = ({ contract, constructorArgs }) =>
           this.owner = owner;
           this.addr1 = addr1;
           this.addr2 = addr2;
-          this.receiver = await this.ERC721Receiver.deploy(RECEIVER_MAGIC_VALUE);
         });
 
         describe('safeMint', function () {

--- a/test/GasUsage.test.js
+++ b/test/GasUsage.test.js
@@ -1,8 +1,8 @@
+const { deployContract } = require('./helpers.js');
+
 describe('ERC721A Gas Usage', function () {
   beforeEach(async function () {
-    this.ERC721A = await ethers.getContractFactory('ERC721AGasReporterMock');
-    this.erc721a = await this.ERC721A.deploy('Azuki', 'AZUKI');
-    await this.erc721a.deployed();
+    this.erc721a = await deployContract('ERC721AGasReporterMock', ['Azuki', 'AZUKI']);
     const [owner, addr1] = await ethers.getSigners();
     this.owner = owner;
     this.addr1 = addr1;

--- a/test/extensions/ERC721ABurnable.test.js
+++ b/test/extensions/ERC721ABurnable.test.js
@@ -1,3 +1,4 @@
+const { deployContract } = require('../helpers.js');
 const { expect } = require('chai');
 const { constants } = require('@openzeppelin/test-helpers');
 const { ZERO_ADDRESS } = constants;
@@ -6,11 +7,7 @@ const createTestSuite = ({ contract, constructorArgs }) =>
   function () {
     context(`${contract}`, function () {
       beforeEach(async function () {
-        this.ERC721ABurnable = await ethers.getContractFactory(contract);
-
-        this.erc721aBurnable = await this.ERC721ABurnable.deploy(...constructorArgs);
-
-        await this.erc721aBurnable.deployed();
+        this.erc721aBurnable = await deployContract(contract, constructorArgs);
 
         this.startTokenId = this.erc721aBurnable.startTokenId
           ? (await this.erc721aBurnable.startTokenId()).toNumber()

--- a/test/extensions/ERC721ABurnableOwnersExplicit.test.js
+++ b/test/extensions/ERC721ABurnableOwnersExplicit.test.js
@@ -1,12 +1,11 @@
+const { deployContract } = require('../helpers.js');
 const { expect } = require('chai');
 const { constants } = require('@openzeppelin/test-helpers');
 const { ZERO_ADDRESS } = constants;
 
 describe('ERC721ABurnableOwnersExplicit', function () {
   beforeEach(async function () {
-    this.ERC721ABurnableOwnersExplicit = await ethers.getContractFactory('ERC721ABurnableOwnersExplicitMock');
-    this.token = await this.ERC721ABurnableOwnersExplicit.deploy('Azuki', 'AZUKI');
-    await this.token.deployed();
+    this.token = await deployContract('ERC721ABurnableOwnersExplicitMock', ['Azuki', 'AZUKI']);
   });
   
   beforeEach(async function () {

--- a/test/extensions/ERC721AOwnersExplicit.test.js
+++ b/test/extensions/ERC721AOwnersExplicit.test.js
@@ -1,3 +1,4 @@
+const { deployContract } = require('../helpers.js');
 const { expect } = require('chai');
 const { constants } = require('@openzeppelin/test-helpers');
 const { ZERO_ADDRESS } = constants;
@@ -6,11 +7,7 @@ const createTestSuite = ({ contract, constructorArgs }) =>
   function () {
     context(`${contract}`, function () {
       beforeEach(async function () {
-        this.ERC721AOwnersExplicit = await ethers.getContractFactory(contract);
-
-        this.erc721aOwnersExplicit = await this.ERC721AOwnersExplicit.deploy(...constructorArgs);
-
-        await this.erc721aOwnersExplicit.deployed();
+        this.erc721aOwnersExplicit = await deployContract(contract, constructorArgs);
 
         this.startTokenId = this.erc721aOwnersExplicit.startTokenId
           ? (await this.erc721aOwnersExplicit.startTokenId()).toNumber()

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,15 @@
+const { ethers } = require("hardhat");
+
+const deployContract = async function (contractName, constructorArgs) {
+	let factory;
+	try {
+		factory = await ethers.getContractFactory(contractName);
+	} catch (e) {
+		factory = await ethers.getContractFactory(contractName + 'UpgradeableWithInit');
+	}
+	let contract = await factory.deploy(...(constructorArgs || []));
+	await contract.deployed();
+	return contract;
+};
+
+module.exports = { deployContract };


### PR DESCRIPTION
The aim is to make the tests compatible with upgradeable mock contracts generated with OpenZeppelin's transpiler. 

