### PR TITLE
Add correct function signature for _setAux

### DIFF
--- a/docs/erc721a.md
+++ b/docs/erc721a.md
@@ -361,7 +361,7 @@ Returns the auxillary data for `owner` (e.g. number of whitelist mint slots used
 ### \_setAux
 
 ```solidity
-function _getAux(address owner) internal view returns (uint64)
+function _setAux(address owner, uint64 aux) internal
 ```
 
 Sets the auxillary data for `owner` (e.g. number of whitelist mint slots used).


### PR DESCRIPTION
Currently, the docs section for `_setAux` displays the function signature for `_getAux`. This PR includes a small update to display the correct function signature as specified in the ERC721A contract.