### PR TITLE
Update new CandyCreator Verified Contract

### DIFF
--- a/projects.md
+++ b/projects.md
@@ -33,7 +33,7 @@ Here are a list of projects that have or will be implementing ERC721A as part of
 - [Mister Otter River Club](https://morc.vercel.app/) | [Etherscan](https://etherscan.io/address/0xa8c724a829a48f551950a783c6ec50e728725026) | [Twitter](https://twitter.com/misterotternft) 
 - [Tasty Bones NFT](https://tastybones.xyz/) | [Etherscan](https://etherscan.io/address/0x1b79c7832ed9358E024F9e46E9c8b6f56633691B) | [Twitter](https://twitter.com/tastybonesnft) 
 - [BASΞD VITALIK](https://basedvitalik.io/) | [Etherscan](https://etherscan.io/address/0xea2dc6f116a4c3d6a15f06b4e8ad582a07c3dd9c) | [Twitter](https://twitter.com/art101nft) 
-- [Candy Chain Web Platform](https://candychain.io) | [Etherscan](https://etherscan.io/address/0x3F28468BC569DcC8E58B465Fa4893340aEB1Cc54) | [Twitter](https://twitter.com/Candy_Chain_)
+- [Candy Chain Web Platform](https://candychain.io) | [Etherscan](https://etherscan.io/address/0x54019e5C4e4fe8d1802cd37B50E707c28A17A5bc) | [Twitter](https://twitter.com/Candy_Chain_)
 - [Underground Ape Club](https://undergroundape.club/) | [Etherscan](https://etherscan.io/address/0xB94b38fCb227350989f95F54F54f43b5Fcc3ccff) | [Twitter](https://twitter.com/undergroundapes) | [Opensea](https://opensea.io/collection/uacofficial)
 - [Delinquentz](https://delinquentz.io/) | [Etherscan](https://etherscan.io/address/0xE4Ee205AF5113e479A0F2FBd25be2eF0C17f952d) | [Twitter](https://twitter.com/dlnqntz) 
 - [Troverse](https://troverse.io/) | [Etherscan](https://etherscan.io/address/0x762bc5880f128dcac29cffdde1cf7ddf4cfc39ee) | [Twitter](https://twitter.com/TroverseNFT) 


### PR DESCRIPTION
We've updated our web platforms code to use a more recent version of ERC721A, and improved our code with custom Solidity errors instead of long revert strings. We utilize the getAux variable for whitelist slots.