### PR TITLE
Update ERC721ABurnable.sol

### DIFF
--- a/contracts/extensions/ERC721ABurnable.sol
+++ b/contracts/extensions/ERC721ABurnable.sol
@@ -18,6 +18,6 @@ abstract contract ERC721ABurnable is ERC721A {
      * - The caller must own `tokenId` or be an approved operator.
      */
     function burn(uint256 tokenId) public virtual {
-        _burn(tokenId, true);
+        _burn(tokenId);
     }
 }

--- a/contracts/extensions/ERC721ABurnable.sol
+++ b/contracts/extensions/ERC721ABurnable.sol
@@ -17,7 +17,7 @@ abstract contract ERC721ABurnable is ERC721A {
      *
      * - The caller must own `tokenId` or be an approved operator.
      */
-    function burn(uint256 tokenId) public virtual {
-        _burn(tokenId);
+    function burn(uint256 tokenId, bool approvalCheck) public virtual {
+        _burn(tokenId, approvalCheck);
     }
 }


### PR DESCRIPTION
Fix the parameters for call to ERC721A internal burn function. Fixes the following error:

```
TypeError: Wrong argument count for function call: 2 arguments given but expected 1.
  --> contracts/token/extensions/ERC721ABurnable.sol:21:9:
   |
21 |         _burn(tokenId, true);
   |         ^^^^^^^^^^^^^^^^^^^^


Error HH600: Compilation failed
```