### PR TITLE
add override and remove immutable in function to fit version under v0.8.8

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -65,7 +65,7 @@ contract ERC721A is Context, ERC165, IERC721A {
     /**
      * @dev Burned tokens are calculated here, use _totalMinted() if you want to count just minted tokens.
      */
-    function totalSupply() public view returns (uint256) {
+    function totalSupply() public view override returns (uint256) {
         // Counter underflow is impossible as _burnCounter cannot be incremented
         // more than _currentIndex - _startTokenId() times
         unchecked {

--- a/contracts/extensions/ERC721ABurnable.sol
+++ b/contracts/extensions/ERC721ABurnable.sol
@@ -18,7 +18,7 @@ abstract contract ERC721ABurnable is ERC721A, IERC721ABurnable {
      *
      * - The caller must own `tokenId` or be an approved operator.
      */
-    function burn(uint256 tokenId) public virtual {
+    function burn(uint256 tokenId) public virtual override {
         _burn(tokenId, true);
     }
 }

--- a/contracts/extensions/ERC721AQueryable.sol
+++ b/contracts/extensions/ERC721AQueryable.sol
@@ -29,7 +29,7 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
      *   - `startTimestamp` = `<Timestamp of start of ownership>`
      *   - `burned = `false`
      */
-    function explicitOwnershipOf(uint256 tokenId) public view returns (TokenOwnership memory) {
+    function explicitOwnershipOf(uint256 tokenId) public view override returns (TokenOwnership memory) {
         TokenOwnership memory ownership;
         if (tokenId < _startTokenId() || tokenId >= _currentIndex) {
             return ownership;
@@ -45,7 +45,7 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
      * @dev Returns an array of `TokenOwnership` structs at `tokenIds` in order.
      * See {ERC721AQueryable-explicitOwnershipOf}
      */
-    function explicitOwnershipsOf(uint256[] memory tokenIds) external view returns (TokenOwnership[] memory) {
+    function explicitOwnershipsOf(uint256[] memory tokenIds) external view override returns (TokenOwnership[] memory) {
         unchecked {
             uint256 tokenIdsLength = tokenIds.length;
             TokenOwnership[] memory ownerships = new TokenOwnership[](tokenIdsLength);
@@ -72,7 +72,7 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
         address owner,
         uint256 start,
         uint256 stop
-    ) external view returns (uint256[] memory) {
+    ) external view override returns (uint256[] memory) {
         unchecked {
             if (start >= stop) revert InvalidQueryRange();
             uint256 tokenIdsIdx;
@@ -139,7 +139,7 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
      * multiple smaller scans if the collection is large enough to cause
      * an out-of-gas error (10K pfp collections should be fine).
      */
-    function tokensOfOwner(address owner) external view returns (uint256[] memory) {
+    function tokensOfOwner(address owner) external view override returns (uint256[] memory) {
         unchecked {
             uint256 tokenIdsIdx;
             address currOwnershipAddr;

--- a/contracts/mocks/StartTokenIdHelper.sol
+++ b/contracts/mocks/StartTokenIdHelper.sol
@@ -9,7 +9,7 @@ pragma solidity ^0.8.4;
  * to be returned by the overriden `_startTokenId()` function of ERC721A in the ERC721AStartTokenId mocks.
  */
 contract StartTokenIdHelper {
-    uint256 public immutable startTokenId;
+    uint256 public startTokenId;
 
     constructor(uint256 startTokenId_) {
         startTokenId = startTokenId_;


### PR DESCRIPTION
contract's solidity version is solidity ^0.8.4, but in code use two feature only support ^0.8.8.

https://blog.soliditylang.org/2021/09/27/solidity-0.8.8-release-announcement/

you can see **No Override for Interface Functions** and **Reading From Immutable Variables** in this article.

so to fit contract version under 0.8.8, I add override for Interface function and remove read immutable variable in one mock contract. 


 
