### PR TITLE
[Do not merge] Experiment: add a little assembly

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -325,12 +325,12 @@ contract ERC721A is Context, ERC165, IERC721A {
         // updatedIndex overflows if _currentIndex + quantity > 1.2e77 (2**256) - 1
         unchecked {
             assembly {
+                // _addressData[to].balance += uint64(quantity);
+                // _addressData[to].numberMinted += uint64(quantity);
                 mstore(0x00, to)
                 mstore(0x20, _addressData.slot)
                 let addressDataSlotHash := keccak256(0x00, 0x40)
                 let addressDataRaw := sload(addressDataSlotHash)
-                // _addressData[to].balance += uint64(quantity);
-                // _addressData[to].numberMinted += uint64(quantity);
                 addressDataRaw := or(
                     and(add(addressDataRaw, quantity), 0xffffffffffffffff),
                     or(
@@ -481,6 +481,8 @@ contract ERC721A is Context, ERC165, IERC721A {
             assembly {
                 // _addressData[from].balance -= 1;
                 // _addressData[to].balance += 1;
+                // Since the balance is at the first slot, we can simply add and sub to 
+                // the raw uint256.
                 mstore(0x00, from)
                 mstore(0x20, _addressData.slot)
                 let addressDataSlotHash := keccak256(0x00, 0x40)
@@ -562,6 +564,8 @@ contract ERC721A is Context, ERC165, IERC721A {
             assembly {
                 // _addressData[from].balance -= 1;
                 // _addressData[from].numberBurned += 1;
+                // Since the balance is at the first slot, we can simply sub to 
+                // the raw uint256. We can also directly add to the burned count.
                 mstore(0x00, from)
                 mstore(0x20, _addressData.slot)
                 let addressDataSlotHash := keccak256(0x00, 0x40)

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -334,6 +334,8 @@ contract ERC721A is Context, ERC165, IERC721A {
                 addressDataRaw := add(add(addressDataRaw, quantity), shl(64, quantity))
                 sstore(addressDataSlotHash, addressDataRaw)
 
+                // _ownerships[startTokenId].addr = to;
+                // _ownerships[startTokenId].startTimestamp = uint64(block.timestamp);
                 mstore(0x00, startTokenId)
                 mstore(0x20, _ownerships.slot)
                 sstore(keccak256(0x00, 0x40), or(to, shl(160, timestamp())))

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -331,14 +331,7 @@ contract ERC721A is Context, ERC165, IERC721A {
                 mstore(0x20, _addressData.slot)
                 let addressDataSlotHash := keccak256(0x00, 0x40)
                 let addressDataRaw := sload(addressDataSlotHash)
-                addressDataRaw := or(
-                    and(add(addressDataRaw, quantity), 0xffffffffffffffff),
-                    or(
-                        shl(64, and(add(shr(64, addressDataRaw), quantity), 0xffffffffffffffff)),
-                        and(addressDataRaw, 
-                            0xffffffffffffffffffffffffffffffff00000000000000000000000000000000)
-                    )
-                )
+                addressDataRaw := add(add(addressDataRaw, quantity), shl(64, quantity))
                 sstore(addressDataSlotHash, addressDataRaw)
 
                 mstore(0x00, startTokenId)
@@ -405,14 +398,7 @@ contract ERC721A is Context, ERC165, IERC721A {
                 mstore(0x20, _addressData.slot)
                 let addressDataSlotHash := keccak256(0x00, 0x40)
                 let addressDataRaw := sload(addressDataSlotHash)
-                addressDataRaw := or(
-                    and(add(addressDataRaw, quantity), 0xffffffffffffffff),
-                    or(
-                        shl(64, and(add(shr(64, addressDataRaw), quantity), 0xffffffffffffffff)),
-                        and(addressDataRaw, 
-                            0xffffffffffffffffffffffffffffffff00000000000000000000000000000000)
-                    )
-                )
+                addressDataRaw := add(add(addressDataRaw, quantity), shl(64, quantity))
                 sstore(addressDataSlotHash, addressDataRaw)
 
                 // _ownerships[startTokenId].addr = to;
@@ -481,8 +467,6 @@ contract ERC721A is Context, ERC165, IERC721A {
             assembly {
                 // _addressData[from].balance -= 1;
                 // _addressData[to].balance += 1;
-                // Since the balance is at the first slot, we can simply add and sub to 
-                // the raw uint256.
                 mstore(0x00, from)
                 mstore(0x20, _addressData.slot)
                 let addressDataSlotHash := keccak256(0x00, 0x40)
@@ -564,8 +548,6 @@ contract ERC721A is Context, ERC165, IERC721A {
             assembly {
                 // _addressData[from].balance -= 1;
                 // _addressData[from].numberBurned += 1;
-                // Since the balance is at the first slot, we can simply sub to 
-                // the raw uint256. We can also directly add to the burned count.
                 mstore(0x00, from)
                 mstore(0x20, _addressData.slot)
                 let addressDataSlotHash := keccak256(0x00, 0x40)


### PR DESCRIPTION
For readability, we shall keep to mostly regular Solidity code.

This experiment demonstrates that an assembly optimized `_mint`, `_safeMint`, `_transfer`, `_burn`,   
can save around 50 to 500 gas (less than 1%). 

This is roughly equivalent to replacing all the structs with raw `uint256`s,  
without those extra fields like `numberMinted`, `startTimestamp`, etc. 

If you super want this to be in ERC721A, drop us a comment or open an issue.  
Or just copy paste it yourself (at your own risk).

**Before:**

```
·---------------------------------------------------------------|---------------------------|-------------|
|                     Solc version: 0.8.11                      ·  Optimizer enabled: true  ·  Runs: 800  ·
································································|···························|·············|
|  Methods                                                                                                 
··········································|·····················|·············|·············|·············|
|  Contract                               ·  Method             ·  Min        ·  Max        ·  Avg        ·
··········································|·····················|·············|·············|·············|
|  ERC721ABurnableMock                    ·  approve            ·      30839  ·      50979  ·      40909  ·
··········································|·····················|·············|·············|·············|
|  ERC721ABurnableMock                    ·  burn               ·      48116  ·     114509  ·      94742  ·
··········································|·····················|·············|·············|·············|
|  ERC721ABurnableMock                    ·  safeMint           ·          -  ·          -  ·     111106  ·
··········································|·····················|·············|·············|·············|
|  ERC721ABurnableMock                    ·  setApprovalForAll  ·      26277  ·      46189  ·      36233  ·
··········································|·····················|·············|·············|·············|
|  ERC721ABurnableMock                    ·  transferFrom       ·      86551  ·      92837  ·      89694  ·
··········································|·····················|·············|·············|·············|
|  ERC721AGasReporterMock                 ·  mintOne            ·      56358  ·      90558  ·      57042  ·
··········································|·····················|·············|·············|·············|
|  ERC721AGasReporterMock                 ·  mintTen            ·      73985  ·     108185  ·      74669  ·
··········································|·····················|·············|·············|·············|
|  ERC721AGasReporterMock                 ·  safeMintOne        ·      59094  ·      93294  ·      59778  ·
··········································|·····················|·············|·············|·············|
|  ERC721AGasReporterMock                 ·  safeMintTen        ·      76699  ·     110899  ·      77383  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  approve            ·          -  ·          -  ·      50911  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  burn               ·          -  ·          -  ·      65320  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  mint               ·      90667  ·      98523  ·      96429  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  safeMint           ·      78306  ·     123064  ·      87696  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  safeTransferFrom   ·      93606  ·      93618  ·      93614  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  setApprovalForAll  ·      46195  ·      46219  ·      46215  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  setAux             ·      27144  ·      44328  ·      32872  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  transferFrom       ·      86549  ·      86573  ·      86568  ·
··········································|·····················|·············|·············|·············|
|  Deployments                                                  ·                                         ·
································································|·············|·············|·············|
|  ERC721ABurnableMock                                          ·          -  ·          -  ·    1295517  ·
································································|·············|·············|·············|
|  ERC721AGasReporterMock                                       ·          -  ·          -  ·    1214810  ·
································································|·············|·············|·············|
|  ERC721AMock                                                  ·          -  ·          -  ·    1459659  ·
·---------------------------------------------------------------|-------------|-------------|-------------|
```

**After:**

```
·---------------------------------------------------------------|---------------------------|-------------|
|                     Solc version: 0.8.11                      ·  Optimizer enabled: true  ·  Runs: 800  ·
································································|···························|·············|
|  Methods                                                      ·              100 gwei/gas               ·
··········································|·····················|·············|·············|·············|
|  Contract                               ·  Method             ·  Min        ·  Max        ·  Avg        ·
··········································|·····················|·············|·············|·············|
|  ERC721ABurnableMock                    ·  approve            ·      30839  ·      50979  ·      40909  ·
··········································|·····················|·············|·············|·············|
|  ERC721ABurnableMock                    ·  burn               ·      47795  ·     114017  ·      94271  ·
··········································|·····················|·············|·············|·············|
|  ERC721ABurnableMock                    ·  safeMint           ·          -  ·          -  ·     110775  ·
··········································|·····················|·············|·············|·············|
|  ERC721ABurnableMock                    ·  setApprovalForAll  ·      26277  ·      46189  ·      36233  ·
··········································|·····················|·············|·············|·············|
|  ERC721ABurnableMock                    ·  transferFrom       ·      86077  ·      92534  ·      89306  ·
··········································|·····················|·············|·············|·············|
|  ERC721AGasReporterMock                 ·  mintOne            ·      56151  ·      90351  ·      56835  ·
··········································|·····················|·············|·············|·············|
|  ERC721AGasReporterMock                 ·  mintTen            ·      73625  ·     107825  ·      74309  ·
··········································|·····················|·············|·············|·············|
|  ERC721AGasReporterMock                 ·  safeMintOne        ·      58916  ·      93116  ·      59600  ·
··········································|·····················|·············|·············|·············|
|  ERC721AGasReporterMock                 ·  safeMintTen        ·      76368  ·     110568  ·      77052  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  approve            ·          -  ·          -  ·      50911  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  burn               ·          -  ·          -  ·      64999  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  mint               ·      90460  ·      98248  ·      96172  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  safeMint           ·      78111  ·     122914  ·      87506  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  safeTransferFrom   ·      93132  ·      93144  ·      93140  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  setApprovalForAll  ·      46195  ·      46219  ·      46215  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  setAux             ·      27144  ·      44328  ·      32872  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  transferFrom       ·      86075  ·      86099  ·      86094  ·
··········································|·····················|·············|·············|·············|
|  Deployments                                                  ·                                         ·
································································|·············|·············|·············|
|  ERC721ABurnableMock                                          ·          -  ·          -  ·    1218044  ·
································································|·············|·············|·············|
|  ERC721AGasReporterMock                                       ·          -  ·          -  ·    1165947  ·
································································|·············|·············|·············|
|  ERC721AMock                                                  ·          -  ·          -  ·    1369235  ·
·---------------------------------------------------------------|-------------|-------------|-------------|
```
