### PR TITLE
Use uint packing instead of structs

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -292,7 +292,7 @@ contract ERC721A is IERC721A {
         address owner = address(uint160(_packedOwnershipOf(tokenId)));
         if (to == owner) revert ApprovalToCurrentOwner();
 
-        if (_msgSenderERC721A() != owner) if(!isApprovedForAll(owner, _msgSenderERC721A())) {
+        if (_msgSenderERC721A() != owner) if (!isApprovedForAll(owner, _msgSenderERC721A())) {
             revert ApprovalCallerNotOwnerNorApproved();
         }
 
@@ -623,6 +623,7 @@ contract ERC721A is IERC721A {
             // - `numberBurned += 1`.
             //
             // We can directly decrement the balance, and increment the number burned.
+            // This is equivalent to `packed -= 1; packed += 1 << BITPOS_NUMBER_BURNED;`.
             _packedAddressData[from] += (1 << BITPOS_NUMBER_BURNED) - 1;
 
             { // Scoped for extra gas optimization.

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -403,25 +403,6 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * @dev Writes the ownership data for mint.
-     */
-    function _mintWriteOwnership(
-        address to,
-        uint256 quantity,
-        uint256 startTokenId
-    ) private {
-        // Updates:
-        // - `address` to the owner.
-        // - `startTimestamp` to the timestamp of minting.
-        // - `burned` to `false`.
-        // - `nextInitialized` to `quantity == 1`.
-        _packedOwnerships[startTokenId] =
-            _addressToUint256(to) |
-            (block.timestamp << BITPOS_START_TIMESTAMP) |
-            (_boolToUint256(quantity == 1) << BITPOS_NEXT_INITIALIZED);
-    }
-
-    /**
      * @dev Safely mints `quantity` tokens and transfers them to `to`.
      *
      * Requirements:
@@ -454,7 +435,15 @@ contract ERC721A is IERC721A {
             // We can directly add to the balance and number minted.
             _packedAddressData[to] += quantity | (quantity << BITPOS_NUMBER_MINTED);
 
-            _mintWriteOwnership(to, quantity, startTokenId);
+            // Updates:
+            // - `address` to the owner.
+            // - `startTimestamp` to the timestamp of minting.
+            // - `burned` to `false`.
+            // - `nextInitialized` to `quantity == 1`.
+            _packedOwnerships[startTokenId] =
+                _addressToUint256(to) |
+                (block.timestamp << BITPOS_START_TIMESTAMP) |
+                (_boolToUint256(quantity == 1) << BITPOS_NEXT_INITIALIZED);
 
             uint256 updatedIndex = startTokenId;
             uint256 end = updatedIndex + quantity;
@@ -506,7 +495,15 @@ contract ERC721A is IERC721A {
             // We can directly add to the balance and number minted.
             _packedAddressData[to] += quantity | (quantity << BITPOS_NUMBER_MINTED);
 
-            _mintWriteOwnership(to, quantity, startTokenId);
+            // Updates:
+            // - `address` to the owner.
+            // - `startTimestamp` to the timestamp of minting.
+            // - `burned` to `false`.
+            // - `nextInitialized` to `quantity == 1`.
+            _packedOwnerships[startTokenId] =
+                _addressToUint256(to) |
+                (block.timestamp << BITPOS_START_TIMESTAMP) |
+                (_boolToUint256(quantity == 1) << BITPOS_NEXT_INITIALIZED);
 
             uint256 updatedIndex = startTokenId;
             uint256 end = updatedIndex + quantity;

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -50,7 +50,7 @@ contract ERC721A is IERC721A {
     // - [160..223] `startTimestamp`
     // - [224]      `burned`
     // - [225]      `nextInitialized`
-    mapping(uint256 => uint256) internal _packedOwnerships;
+    mapping(uint256 => uint256) private _packedOwnerships;
 
     // Mapping owner address to address data.
     //
@@ -157,7 +157,7 @@ contract ERC721A is IERC721A {
     /**
      * Returns the packed ownership data of `tokenId`.
      */
-    function _packedOwnershipOf(uint256 tokenId) internal view returns (uint256) {
+    function _packedOwnershipOf(uint256 tokenId) private view returns (uint256) {
         uint256 curr = tokenId;
 
         unchecked {
@@ -185,7 +185,7 @@ contract ERC721A is IERC721A {
     /**
      * Returns the unpacked `TokenOwnership` struct from `packed`.
      */
-    function _unpackedOwnership(uint256 packed) internal pure returns (TokenOwnership memory ownership) {
+    function _unpackedOwnership(uint256 packed) private pure returns (TokenOwnership memory ownership) {
         ownership.addr = address(uint160(packed));
         ownership.startTimestamp = uint64(packed >> 160);
         ownership.burned = packed & (1 << 224) != 0;
@@ -196,6 +196,15 @@ contract ERC721A is IERC721A {
      */
     function _ownershipAt(uint256 index) internal view returns (TokenOwnership memory) {
         return _unpackedOwnership(_packedOwnerships[index]);
+    }
+
+    /**
+     * @dev Initializes the ownership slot minted at `index` for efficiency purposes.
+     */
+    function _initializeOwnershipAt(uint256 index) internal {
+        if (_packedOwnerships[index] == 0) {
+            _packedOwnerships[index] = _packedOwnershipOf(index);
+        }
     }
 
     /**

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -177,7 +177,11 @@ contract ERC721A is IERC721A {
      */
     function _setAux(address owner, uint64 aux) internal {
         uint256 packed = _packedAddressData[owner];
-        packed = (packed & BITMASK_AUX_COMPLEMENT) | (uint256(aux) << BITPOS_AUX);
+        uint256 auxCasted;
+        assembly { // Cast aux without masking.
+            auxCasted := aux
+        }
+        packed = (packed & BITMASK_AUX_COMPLEMENT) | (auxCasted << BITPOS_AUX);
         _packedAddressData[owner] = packed;
     }
 

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -43,12 +43,22 @@ contract ERC721A is IERC721A {
 
     // Mapping from token ID to ownership details
     // An empty struct value does not necessarily mean the token is unowned. 
-    // See _ownershipOf implementation for details.
-    // `packed = (addr) | (startTimestamp << 160) | (burned << 224) | (nextInitialized << 225)`.
+    // See `_packedOwnershipOf` implementation for details.
+    //
+    // Bits Layout:
+    // - [0..159]   `addr`
+    // - [160..223] `startTimestamp`
+    // - [224]      `burned`
+    // - [225]      `nextInitialized`
     mapping(uint256 => uint256) internal _packedOwnerships;
 
     // Mapping owner address to address data.
-    // `packed = (balance) | (numberMinted << 64) | (numberBurned << 128) | (aux << 192)`. 
+    //
+    // Bits Layout:
+    // - [0..63]    `balance`
+    // - [64..127]  `numberMinted`
+    // - [128..191] `numberBurned`
+    // - [192..255] `aux`
     mapping(address => uint256) private _packedAddressData;
 
     // Mapping from token ID to approved address.

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -433,7 +433,7 @@ contract ERC721A is IERC721A {
             // - `numberMinted += quantity`.
             //
             // We can directly add to the balance and number minted.
-            _packedAddressData[to] += quantity | (quantity << BITPOS_NUMBER_MINTED);
+            _packedAddressData[to] += quantity * ((1 << BITPOS_NUMBER_MINTED) | 1);
 
             // Updates:
             // - `address` to the owner.
@@ -493,7 +493,7 @@ contract ERC721A is IERC721A {
             // - `numberMinted += quantity`.
             //
             // We can directly add to the balance and number minted.
-            _packedAddressData[to] += quantity | (quantity << BITPOS_NUMBER_MINTED);
+            _packedAddressData[to] += quantity * ((1 << BITPOS_NUMBER_MINTED) | 1);
 
             // Updates:
             // - `address` to the owner.

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -47,14 +47,11 @@ contract ERC721A is IERC721A {
     // The bit position of `startTimestamp` in packed ownership.
     uint256 private constant BITPOS_START_TIMESTAMP = 160;
 
-    // The bit position of the `burned` bit in packed ownership.
-    uint256 private constant BITPOS_BURNED = 224;
-
-    // The bit position of the `nextInitialized` bit in packed ownership.
-    uint256 private constant BITPOS_NEXT_INITIALIZED = 225;
-
     // The bit mask of the `burned` bit in packed ownership.
     uint256 private constant BITMASK_BURNED = 1 << 224;
+    
+    // The bit position of the `nextInitialized` bit in packed ownership.
+    uint256 private constant BITPOS_NEXT_INITIALIZED = 225;
 
     // The bit mask of the `nextInitialized` bit in packed ownership.
     uint256 private constant BITMASK_NEXT_INITIALIZED = 1 << 225;
@@ -645,8 +642,8 @@ contract ERC721A is IERC721A {
             _packedOwnerships[tokenId] =
                 _addressToUint256(from) |
                 (block.timestamp << BITPOS_START_TIMESTAMP) |
-                BITMASK_NEXT_INITIALIZED |
-                BITMASK_BURNED;
+                BITMASK_BURNED | 
+                BITMASK_NEXT_INITIALIZED;
 
             // If the next slot may not have been initialized (i.e. `nextInitialized == false`) .
             if (prevOwnershipPacked & BITMASK_NEXT_INITIALIZED == 0) {

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -529,7 +529,7 @@ contract ERC721A is IERC721A {
                 _packedOwnerships[tokenId] = packed;    
             }
 
-            // If the next slot may not have been initialized.
+            // If the next slot may not have been initialized (i.e. `nextInitialized == false`) .
             if (prevOwnershipPacked & (1 << 225) == 0) { 
                 uint256 nextTokenId = tokenId + 1;
                 // If the next slot's address is zero and not burned (i.e. packed value is zero).
@@ -609,7 +609,7 @@ contract ERC721A is IERC721A {
                 _packedOwnerships[tokenId] = packed;    
             }
 
-            // If the next slot may not have been initialized.
+            // If the next slot may not have been initialized (i.e. `nextInitialized == false`) .
             if (prevOwnershipPacked & (1 << 225) == 0) { 
                 uint256 nextTokenId = tokenId + 1;
                 // If the next slot's address is zero and not burned (i.e. packed value is zero).

--- a/contracts/IERC721A.sol
+++ b/contracts/IERC721A.sol
@@ -73,7 +73,6 @@ interface IERC721A {
      */
     error URIQueryForNonexistentToken();
 
-    // Compiler will pack this into a single 256bit word.
     struct TokenOwnership {
         // The address of the owner.
         address addr;
@@ -81,20 +80,6 @@ interface IERC721A {
         uint64 startTimestamp;
         // Whether the token has been burned.
         bool burned;
-    }
-
-    // Compiler will pack this into a single 256bit word.
-    struct AddressData {
-        // Realistically, 2**64-1 is more than enough.
-        uint64 balance;
-        // Keeps track of mint count with minimal overhead for tokenomics.
-        uint64 numberMinted;
-        // Keeps track of burn count with minimal overhead for tokenomics.
-        uint64 numberBurned;
-        // For miscellaneous variable(s) pertaining to the address
-        // (e.g. number of whitelist mint slots used).
-        // If there are multiple variables, please pack them into a uint64.
-        uint64 aux;
     }
 
     /**

--- a/contracts/IERC721A.sol
+++ b/contracts/IERC721A.sol
@@ -84,7 +84,7 @@ interface IERC721A {
 
     /**
      * @dev Returns the total amount of tokens stored by the contract.
-     * 
+     *
      * Burned tokens are calculated here, use `_totalMinted()` if you want to count just minted tokens.
      */
     function totalSupply() external view returns (uint256);

--- a/contracts/extensions/ERC721AOwnersExplicit.sol
+++ b/contracts/extensions/ERC721AOwnersExplicit.sol
@@ -11,12 +11,12 @@ abstract contract ERC721AOwnersExplicit is ERC721A {
      * No more ownership slots to explicity initialize.
      */
     error AllOwnershipsHaveBeenSet();
-    
+
     /**
      * The `quantity` must be more than zero.
      */
     error QuantityMustBeNonZero();
-    
+
     /**
      * At least one token needs to be minted.
      */

--- a/contracts/extensions/ERC721AOwnersExplicit.sol
+++ b/contracts/extensions/ERC721AOwnersExplicit.sol
@@ -47,10 +47,11 @@ abstract contract ERC721AOwnersExplicit is ERC721A {
             }
 
             for (uint256 i = _nextOwnerToExplicitlySet; i <= endIndex; i++) {
-                if (_ownerships[i].addr == address(0) && !_ownerships[i].burned) {
+                uint256 packed = _packedOwnerships[i];
+                if (packed == 0) {
                     TokenOwnership memory ownership = _ownershipOf(i);
-                    _ownerships[i].addr = ownership.addr;
-                    _ownerships[i].startTimestamp = ownership.startTimestamp;
+                    _packedOwnerships[i] = (uint256(uint160(ownership.addr)) | 
+                        (uint256(ownership.startTimestamp) << 160));
                 }
             }
 

--- a/contracts/extensions/ERC721AOwnersExplicit.sol
+++ b/contracts/extensions/ERC721AOwnersExplicit.sol
@@ -47,11 +47,8 @@ abstract contract ERC721AOwnersExplicit is ERC721A {
             }
 
             for (uint256 i = _nextOwnerToExplicitlySet; i <= endIndex; i++) {
-                uint256 packed = _packedOwnerships[i];
-                if (packed == 0) {
-                    TokenOwnership memory ownership = _ownershipOf(i);
-                    _packedOwnerships[i] = (uint256(uint160(ownership.addr)) | 
-                        (uint256(ownership.startTimestamp) << 160));
+                if (_packedOwnerships[i] == 0) {
+                    _packedOwnerships[i] = _packedOwnershipOf(i);
                 }
             }
 

--- a/contracts/extensions/ERC721AOwnersExplicit.sol
+++ b/contracts/extensions/ERC721AOwnersExplicit.sol
@@ -47,9 +47,7 @@ abstract contract ERC721AOwnersExplicit is ERC721A {
             }
 
             for (uint256 i = _nextOwnerToExplicitlySet; i <= endIndex; i++) {
-                if (_packedOwnerships[i] == 0) {
-                    _packedOwnerships[i] = _packedOwnershipOf(i);
-                }
+                _initializeOwnershipAt(i);
             }
 
             nextOwnerToExplicitlySet = endIndex + 1;

--- a/contracts/extensions/ERC721AQueryable.sol
+++ b/contracts/extensions/ERC721AQueryable.sol
@@ -35,7 +35,7 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
         if (tokenId < _startTokenId() || tokenId >= _currentIndex) {
             return ownership;
         }
-        ownership = _ownerships[tokenId];
+        ownership = _ownershipAt(tokenId);
         if (ownership.burned) {
             return ownership;
         }
@@ -111,7 +111,7 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
                 currOwnershipAddr = ownership.addr;
             }
             for (uint256 i = start; i != stop && tokenIdsIdx != tokenIdsMaxLength; ++i) {
-                ownership = _ownerships[i];
+                ownership = _ownershipAt(i);
                 if (ownership.burned) {
                     continue;
                 }
@@ -148,7 +148,7 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
             uint256[] memory tokenIds = new uint256[](tokenIdsLength);
             TokenOwnership memory ownership;
             for (uint256 i = _startTokenId(); tokenIdsIdx != tokenIdsLength; ++i) {
-                ownership = _ownerships[i];
+                ownership = _ownershipAt(i);
                 if (ownership.burned) {
                     continue;
                 }

--- a/contracts/mocks/ERC721ABurnableMock.sol
+++ b/contracts/mocks/ERC721ABurnableMock.sol
@@ -18,7 +18,7 @@ contract ERC721ABurnableMock is ERC721A, ERC721ABurnable {
     }
 
     function getOwnershipAt(uint256 index) public view returns (TokenOwnership memory) {
-        return _ownerships[index];
+        return _ownershipAt(index);
     }
 
     function totalMinted() public view returns (uint256) {

--- a/contracts/mocks/ERC721ABurnableMock.sol
+++ b/contracts/mocks/ERC721ABurnableMock.sol
@@ -24,4 +24,8 @@ contract ERC721ABurnableMock is ERC721A, ERC721ABurnable {
     function totalMinted() public view returns (uint256) {
         return _totalMinted();
     }
+
+    function numberBurned(address owner) public view returns (uint256) {
+        return _numberBurned(owner);
+    }
 }

--- a/contracts/mocks/ERC721ABurnableOwnersExplicitMock.sol
+++ b/contracts/mocks/ERC721ABurnableOwnersExplicitMock.sol
@@ -23,6 +23,6 @@ contract ERC721ABurnableOwnersExplicitMock is ERC721A, ERC721ABurnable, ERC721AO
     }
 
     function getOwnershipAt(uint256 index) public view returns (TokenOwnership memory) {
-        return _ownerships[index];
+        return _ownershipAt(index);
     }
 }

--- a/contracts/mocks/ERC721AMock.sol
+++ b/contracts/mocks/ERC721AMock.sol
@@ -56,4 +56,8 @@ contract ERC721AMock is ERC721A {
     function toString(uint256 x) public pure returns (string memory) {
         return _toString(x);
     }
+
+    function getOwnershipAt(uint256 index) public view returns (TokenOwnership memory) {
+        return _ownershipAt(index);
+    }
 }

--- a/contracts/mocks/ERC721AOwnersExplicitMock.sol
+++ b/contracts/mocks/ERC721AOwnersExplicitMock.sol
@@ -17,7 +17,7 @@ contract ERC721AOwnersExplicitMock is ERC721AOwnersExplicit {
         _setOwnersExplicit(quantity);
     }
 
-    function getOwnershipAt(uint256 tokenId) public view returns (TokenOwnership memory) {
-        return _ownerships[tokenId];
+    function getOwnershipAt(uint256 index) public view returns (TokenOwnership memory) {
+        return _ownershipAt(index);
     }
 }

--- a/contracts/mocks/ERC721AQueryableOwnersExplicitMock.sol
+++ b/contracts/mocks/ERC721AQueryableOwnersExplicitMock.sol
@@ -15,6 +15,6 @@ contract ERC721AQueryableOwnersExplicitMock is ERC721AQueryableMock, ERC721AOwne
     }
 
     function getOwnershipAt(uint256 index) public view returns (TokenOwnership memory) {
-        return _ownerships[index];
+        return _ownershipAt(index);
     }
 }

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -1,4 +1,4 @@
-const { deployContract } = require('./helpers.js');
+const { deployContract, getBlockTimestamp, mineBlockTimestamp } = require('./helpers.js');
 const { expect } = require('chai');
 const { BigNumber } = require('ethers');
 const { constants } = require('@openzeppelin/test-helpers');
@@ -205,7 +205,17 @@ const createTestSuite = ({ contract, constructorArgs }) =>
               this.from = sender.address;
               this.to = this.receiver.address;
               await this.erc721a.connect(sender).setApprovalForAll(this.to, true);
+
+              const ownershipBefore = await this.erc721a.getOwnershipAt(this.tokenId);
+              this.timestampBefore = parseInt(ownershipBefore.startTimestamp);
+              this.timestampToMine = (await getBlockTimestamp()) + 100;
+              await mineBlockTimestamp(this.timestampToMine);
+              this.timestampMined = await getBlockTimestamp();
+
               this.transferTx = await this.erc721a.connect(sender)[transferFn](this.from, this.to, this.tokenId);
+
+              const ownershipAfter = await this.erc721a.getOwnershipAt(this.tokenId);
+              this.timestampAfter = parseInt(ownershipAfter.startTimestamp);
             });
 
             it('transfers the ownership of the given token ID to the given address', async function () {
@@ -224,6 +234,13 @@ const createTestSuite = ({ contract, constructorArgs }) =>
 
             it('adjusts owners balances', async function () {
               expect(await this.erc721a.balanceOf(this.from)).to.be.equal(1);
+            });
+
+            it('startTimestamp updated correctly', async function () {
+              expect(this.timestampBefore).to.be.lt(this.timestampToMine);
+              expect(this.timestampAfter).to.be.gte(this.timestampToMine);
+              expect(this.timestampAfter).to.be.gt(this.timestampBefore);
+              expect(this.timestampToMine).to.be.eq(this.timestampMined);
             });
           };
 

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -239,7 +239,6 @@ const createTestSuite = ({ contract, constructorArgs }) =>
             it('startTimestamp updated correctly', async function () {
               expect(this.timestampBefore).to.be.lt(this.timestampToMine);
               expect(this.timestampAfter).to.be.gte(this.timestampToMine);
-              expect(this.timestampAfter).to.be.gt(this.timestampBefore);
               expect(this.timestampToMine).to.be.eq(this.timestampMined);
             });
           };

--- a/test/GasUsage.test.js
+++ b/test/GasUsage.test.js
@@ -39,4 +39,15 @@ describe('ERC721A Gas Usage', function () {
       }
     });
   });
+
+  context('transferFrom', function () {
+    it('transfer to and fro', async function () {
+      await this.erc721a.mintTen(this.addr1.address);
+      await this.erc721a.mintTen(this.owner.address);
+      for (let i = 0; i < 10; ++i) {
+        await this.erc721a.connect(this.addr1).transferFrom(this.addr1.address, this.owner.address, 1);
+        await this.erc721a.connect(this.owner).transferFrom(this.owner.address, this.addr1.address, 1);
+      }  
+    });
+  });
 });

--- a/test/GasUsage.test.js
+++ b/test/GasUsage.test.js
@@ -41,7 +41,7 @@ describe('ERC721A Gas Usage', function () {
   });
 
   context('transferFrom', function () {
-    it('transfer to and fro', async function () {
+    it('transfer to and from two addresses', async function () {
       await this.erc721a.mintTen(this.addr1.address);
       await this.erc721a.mintTen(this.owner.address);
       for (let i = 0; i < 10; ++i) {

--- a/test/extensions/ERC721ABurnable.test.js
+++ b/test/extensions/ERC721ABurnable.test.js
@@ -1,4 +1,4 @@
-const { deployContract } = require('../helpers.js');
+const { deployContract, getBlockTimestamp, mineBlockTimestamp } = require('../helpers.js');
 const { expect } = require('chai');
 const { constants } = require('@openzeppelin/test-helpers');
 const { ZERO_ADDRESS } = constants;
@@ -42,6 +42,12 @@ const createTestSuite = ({ contract, constructorArgs }) =>
             expect(supplyNow).to.equal(supplyBefore - (i + 1));
           }
         });
+      });
+
+      it('changes numberBurned', async function () {
+        expect(await this.erc721aBurnable.numberBurned(this.addr1.address)).to.equal(1);
+        await this.erc721aBurnable.connect(this.addr1).burn(this.startTokenId);
+        expect(await this.erc721aBurnable.numberBurned(this.addr1.address)).to.equal(2);
       });
 
       it('changes exists', async function () {
@@ -104,6 +110,22 @@ const createTestSuite = ({ contract, constructorArgs }) =>
 
       it('adjusts owners balances', async function () {
         expect(await this.erc721aBurnable.balanceOf(this.addr1.address)).to.be.equal(this.numTestTokens - 1);
+      });
+
+      it('startTimestamp updated correctly', async function () {
+        const tokenIdToBurn = this.burnedTokenId + 1;
+        const ownershipBefore = await this.erc721aBurnable.getOwnershipAt(tokenIdToBurn);
+        const timestampBefore = parseInt(ownershipBefore.startTimestamp);
+        const timestampToMine = (await getBlockTimestamp()) + 100;
+        await mineBlockTimestamp(timestampToMine);
+        const timestampMined = await getBlockTimestamp();
+        await this.erc721aBurnable.connect(this.addr1).burn(tokenIdToBurn);
+        const ownershipAfter = await this.erc721aBurnable.getOwnershipAt(tokenIdToBurn);
+        const timestampAfter = parseInt(ownershipAfter.startTimestamp);
+        expect(timestampBefore).to.be.lt(timestampToMine);
+        expect(timestampAfter).to.be.gte(timestampToMine);
+        expect(timestampAfter).to.be.gt(timestampBefore);
+        expect(timestampToMine).to.be.eq(timestampMined);
       });
 
       describe('ownerships correctly set', async function () {

--- a/test/extensions/ERC721ABurnable.test.js
+++ b/test/extensions/ERC721ABurnable.test.js
@@ -124,7 +124,6 @@ const createTestSuite = ({ contract, constructorArgs }) =>
         const timestampAfter = parseInt(ownershipAfter.startTimestamp);
         expect(timestampBefore).to.be.lt(timestampToMine);
         expect(timestampAfter).to.be.gte(timestampToMine);
-        expect(timestampAfter).to.be.gt(timestampBefore);
         expect(timestampToMine).to.be.eq(timestampMined);
       });
 

--- a/test/extensions/ERC721AQueryable.test.js
+++ b/test/extensions/ERC721AQueryable.test.js
@@ -252,8 +252,8 @@ const createTestSuite = ({ contract, constructorArgs, setOwnersExplicit = false 
             const tokenIds = [].concat(this.owner.expected.tokens, this.addr3.expected.tokens);
             const explicitOwnerships = await this.erc721aQueryable.explicitOwnershipsOf(tokenIds);
             for (let i = 0; i < tokenIds.length; ++i) {
-              const tokenId = await this.erc721aQueryable.ownerOf(tokenIds[i]);
-              expectExplicitOwnershipExists(explicitOwnerships[i], tokenId);
+              const owner = await this.erc721aQueryable.ownerOf(tokenIds[i]);
+              expectExplicitOwnershipExists(explicitOwnerships[i], owner);
             }
           });
 
@@ -263,8 +263,8 @@ const createTestSuite = ({ contract, constructorArgs, setOwnersExplicit = false 
             const explicitOwnerships = await this.erc721aQueryable.explicitOwnershipsOf(tokenIds);
             expectExplicitOwnershipBurned(explicitOwnerships[0], this.owner.address);
             for (let i = 1; i < tokenIds.length; ++i) {
-              const tokenId = await this.erc721aQueryable.ownerOf(tokenIds[i]);
-              expectExplicitOwnershipExists(explicitOwnerships[i], tokenId);
+              const owner = await this.erc721aQueryable.ownerOf(tokenIds[i]);
+              expectExplicitOwnershipExists(explicitOwnerships[i], owner);
             }
           });
 
@@ -274,8 +274,8 @@ const createTestSuite = ({ contract, constructorArgs, setOwnersExplicit = false 
             const explicitOwnerships = await this.erc721aQueryable.explicitOwnershipsOf(tokenIds);
             expectExplicitOwnershipExists(explicitOwnerships[0], this.addr4.address);
             for (let i = 1; i < tokenIds.length; ++i) {
-              const tokenId = await this.erc721aQueryable.ownerOf(tokenIds[i]);
-              expectExplicitOwnershipExists(explicitOwnerships[i], tokenId);
+              const owner = await this.erc721aQueryable.ownerOf(tokenIds[i]);
+              expectExplicitOwnershipExists(explicitOwnerships[i], owner);
             }
           });
 
@@ -284,8 +284,8 @@ const createTestSuite = ({ contract, constructorArgs, setOwnersExplicit = false 
             const explicitOwnerships = await this.erc721aQueryable.explicitOwnershipsOf(tokenIds);
             expectExplicitOwnershipNotExists(explicitOwnerships[0]);
             for (let i = 1; i < tokenIds.length; ++i) {
-              const tokenId = await this.erc721aQueryable.ownerOf(tokenIds[i]);
-              expectExplicitOwnershipExists(explicitOwnerships[i], tokenId);
+              const owner = await this.erc721aQueryable.ownerOf(tokenIds[i]);
+              expectExplicitOwnershipExists(explicitOwnerships[i], owner);
             }
           });
         });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -12,4 +12,13 @@ const deployContract = async function (contractName, constructorArgs) {
   return contract;
 };
 
-module.exports = { deployContract };
+const getBlockTimestamp = async function () {
+  return parseInt((await ethers.provider.getBlock('latest'))['timestamp']);
+};
+
+const mineBlockTimestamp = async function (timestamp) {
+  await ethers.provider.send('evm_setNextBlockTimestamp', [timestamp]);
+  await ethers.provider.send('evm_mine');
+};
+
+module.exports = { deployContract, getBlockTimestamp, mineBlockTimestamp };


### PR DESCRIPTION
This PR is made in preparation for #267. 

This is a breaking change, as the internal `_ownerships` mapping is renamed to `_packedOwnerships`.

Using uints allow us to write most of the packing logic in Solidity instead of assembly. This allows us to keep the code compatible with the diamonds transpiler we are planning to use in the near future. Also, it is easier to read, and surprisingly more performant. 

This PR is inspired by and includes #270. I’ve tried the idea with structs: it added quite a bit of overhead because of the many values that are often needlessly unpacked by the compiler. Manual unpacking allows us to achieve a much lower overhead. 

Additional tests have been added to ensure that the `startTimestamp`s are packed / unpacked properly. 

**Before:**

```
·---------------------------------------------------------------|---------------------------|-------------|
|                     Solc version: 0.8.11                      ·  Optimizer enabled: true  ·  Runs: 800  ·
································································|···························|·············|
|  Methods                                                                                                 
··········································|·····················|·············|·············|·············|
|  Contract                               ·  Method             ·  Min        ·  Max        ·  Avg        ·
··········································|·····················|·············|·············|·············|
|  ERC721ABurnableMock                    ·  approve            ·      30777  ·      50917  ·      40847  ·
··········································|·····················|·············|·············|·············|
|  ERC721ABurnableMock                    ·  burn               ·      46142  ·     112535  ·      92768  ·
··········································|·····················|·············|·············|·············|
|  ERC721ABurnableMock                    ·  safeMint           ·          -  ·          -  ·     111106  ·
··········································|·····················|·············|·············|·············|
|  ERC721ABurnableMock                    ·  setApprovalForAll  ·      26277  ·      46189  ·      36233  ·
··········································|·····················|·············|·············|·············|
|  ERC721ABurnableMock                    ·  transferFrom       ·      84577  ·      90863  ·      87720  ·
··········································|·····················|·············|·············|·············|
|  ERC721AGasReporterMock                 ·  mintOne            ·      56358  ·      90558  ·      57042  ·
··········································|·····················|·············|·············|·············|
|  ERC721AGasReporterMock                 ·  mintTen            ·      73985  ·     108185  ·      75629  ·
··········································|·····················|·············|·············|·············|
|  ERC721AGasReporterMock                 ·  safeMintOne        ·      59094  ·      93294  ·      59778  ·
··········································|·····················|·············|·············|·············|
|  ERC721AGasReporterMock                 ·  safeMintTen        ·      76699  ·     110899  ·      77383  ·
··········································|·····················|·············|·············|·············|
|  ERC721AGasReporterMock                 ·  transferFrom       ·      47175  ·      86955  ·      49164  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  approve            ·          -  ·          -  ·      50849  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  burn               ·          -  ·          -  ·      63346  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  mint               ·      90667  ·      98499  ·      96413  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  safeMint           ·      78306  ·     123064  ·      87877  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  safeTransferFrom   ·      91614  ·      91626  ·      91623  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  setApprovalForAll  ·      46195  ·      46219  ·      46216  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  setAux             ·      27144  ·      44328  ·      32872  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  transferFrom       ·      84575  ·      84599  ·      84594  ·
··········································|·····················|·············|·············|·············|
|  Deployments                                                  ·                                         ·
································································|·············|·············|·············|
|  ERC721ABurnableMock                                          ·          -  ·          -  ·    1300089  ·
································································|·············|·············|·············|
|  ERC721AGasReporterMock                                       ·          -  ·          -  ·    1213358  ·
································································|·············|·············|·············|
|  ERC721AMock                                                  ·          -  ·          -  ·    1464231  ·
·---------------------------------------------------------------|-------------|-------------|-------------|
```

**After:**

```
·---------------------------------------------------------------|---------------------------|-------------|
|                     Solc version: 0.8.11                      ·  Optimizer enabled: true  ·  Runs: 800  ·
································································|···························|·············|
|  Methods                                                                                                 
··········································|·····················|·············|·············|·············|
|  Contract                               ·  Method             ·  Min        ·  Max        ·  Avg        ·
··········································|·····················|·············|·············|·············|
|  ERC721ABurnableMock                    ·  approve            ·      30453  ·      50593  ·      40523  ·
··········································|·····················|·············|·············|·············|
|  ERC721ABurnableMock                    ·  burn               ·      43393  ·     111032  ·      91192  ·
··········································|·····················|·············|·············|·············|
|  ERC721ABurnableMock                    ·  safeMint           ·          -  ·          -  ·     110959  ·
··········································|·····················|·············|·············|·············|
|  ERC721ABurnableMock                    ·  setApprovalForAll  ·      26277  ·      46189  ·      36233  ·
··········································|·····················|·············|·············|·············|
|  ERC721ABurnableMock                    ·  transferFrom       ·      83946  ·      89685  ·      86816  ·
··········································|·····················|·············|·············|·············|
|  ERC721AGasReporterMock                 ·  mintOne            ·      56217  ·      90417  ·      56901  ·
··········································|·····················|·············|·············|·············|
|  ERC721AGasReporterMock                 ·  mintTen            ·      73844  ·     108044  ·      75488  ·
··········································|·····················|·············|·············|·············|
|  ERC721AGasReporterMock                 ·  safeMintOne        ·      58947  ·      93147  ·      59631  ·
··········································|·····················|·············|·············|·············|
|  ERC721AGasReporterMock                 ·  safeMintTen        ·      76552  ·     110752  ·      77236  ·
··········································|·····················|·············|·············|·············|
|  ERC721AGasReporterMock                 ·  transferFrom       ·      44489  ·      86180  ·      46574  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  approve            ·          -  ·          -  ·      50547  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  burn               ·          -  ·          -  ·      60597  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  mint               ·      90526  ·      98358  ·      96272  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  safeMint           ·      78159  ·     122917  ·      87730  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  safeTransferFrom   ·      91008  ·      91020  ·      91017  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  setApprovalForAll  ·      46195  ·      46219  ·      46216  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  setAux             ·      27145  ·      44329  ·      32873  ·
··········································|·····················|·············|·············|·············|
|  ERC721AMock                            ·  transferFrom       ·      83966  ·      83990  ·      83985  ·
··········································|·····················|·············|·············|·············|
|  Deployments                                                  ·                                         ·
································································|·············|·············|·············|
|  ERC721ABurnableMock                                          ·          -  ·          -  ·    1213610  ·
································································|·············|·············|·············|
|  ERC721AGasReporterMock                                       ·          -  ·          -  ·    1116449  ·
································································|·············|·············|·············|
|  ERC721AMock                                                  ·          -  ·          -  ·    1329475  ·
·---------------------------------------------------------------|-------------|-------------|-------------|
```