### PR TITLE
Remove Approval event in _transfer

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -214,7 +214,8 @@ contract ERC721A is Context, ERC165, IERC721A {
             revert ApprovalCallerNotOwnerNorApproved();
         }
 
-        _approve(to, tokenId, owner);
+        _tokenApprovals[tokenId] = to;
+        emit Approval(owner, to, tokenId);
     }
 
     /**
@@ -419,7 +420,7 @@ contract ERC721A is Context, ERC165, IERC721A {
 
         _beforeTokenTransfers(from, to, tokenId, 1);
 
-        // Clear approvals from the previous owner
+        // Clear approvals from the previous owner.
         delete _tokenApprovals[tokenId];
 
         // Underflow of the sender's balance is impossible because we check for
@@ -483,7 +484,7 @@ contract ERC721A is Context, ERC165, IERC721A {
 
         _beforeTokenTransfers(from, address(0), tokenId, 1);
 
-        // Clear approvals from the previous owner
+        // Clear approvals from the previous owner.
         delete _tokenApprovals[tokenId];
 
         // Underflow of the sender's balance is impossible because we check for
@@ -521,20 +522,6 @@ contract ERC721A is Context, ERC165, IERC721A {
         unchecked {
             _burnCounter++;
         }
-    }
-
-    /**
-     * @dev Approve `to` to operate on `tokenId`
-     *
-     * Emits a {Approval} event.
-     */
-    function _approve(
-        address to,
-        uint256 tokenId,
-        address owner
-    ) private {
-        _tokenApprovals[tokenId] = to;
-        emit Approval(owner, to, tokenId);
     }
 
     /**

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -420,7 +420,7 @@ contract ERC721A is Context, ERC165, IERC721A {
         _beforeTokenTransfers(from, to, tokenId, 1);
 
         // Clear approvals from the previous owner
-        _approve(address(0), tokenId, from);
+        delete _tokenApprovals[tokenId];
 
         // Underflow of the sender's balance is impossible because we check for
         // ownership above and the recipient's balance can't realistically overflow.
@@ -484,7 +484,7 @@ contract ERC721A is Context, ERC165, IERC721A {
         _beforeTokenTransfers(from, address(0), tokenId, 1);
 
         // Clear approvals from the previous owner
-        _approve(address(0), tokenId, from);
+        delete _tokenApprovals[tokenId];
 
         // Underflow of the sender's balance is impossible because we check for
         // ownership above and the recipient's balance can't realistically overflow.

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -221,12 +221,6 @@ const createTestSuite = ({ contract, constructorArgs }) =>
               expect(await this.erc721a.getApproved(this.tokenId)).to.be.equal(ZERO_ADDRESS);
             });
 
-            it('emits an Approval event', async function () {
-              await expect(this.transferTx)
-                .to.emit(this.erc721a, 'Approval')
-                .withArgs(this.from, ZERO_ADDRESS, this.tokenId);
-            });
-
             it('adjusts owners balances', async function () {
               expect(await this.erc721a.balanceOf(this.from)).to.be.equal(1);
             });


### PR DESCRIPTION
As per: https://eips.ethereum.org/EIPS/eip-721

```
/// @dev This emits when the approved address for an NFT is changed or
///  reaffirmed. The zero address indicates there is no approved address.
///  When a Transfer event emits, this also indicates that the approved
///  address for that NFT (if any) is reset to none.
```

The `Transfer` event makes the `Approval` event redundant.

Solmate does not emit a `Transfer` event in `_transfer`.

https://github.com/Rari-Capital/solmate/blob/main/src/tokens/ERC721.sol

This saves around 2000 gas.

Thanks @0xPhaze #270.