### PR TITLE
Rename _msgSender

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -217,7 +217,7 @@ contract ERC721A is IERC721A {
         address owner = ERC721A.ownerOf(tokenId);
         if (to == owner) revert ApprovalToCurrentOwner();
 
-        if (_msgSender() != owner) if(!isApprovedForAll(owner, _msgSender())) {
+        if (_erc721a__msgSender() != owner) if(!isApprovedForAll(owner, _erc721a__msgSender())) {
             revert ApprovalCallerNotOwnerNorApproved();
         }
 
@@ -238,10 +238,10 @@ contract ERC721A is IERC721A {
      * @dev See {IERC721-setApprovalForAll}.
      */
     function setApprovalForAll(address operator, bool approved) public virtual override {
-        if (operator == _msgSender()) revert ApproveToCaller();
+        if (operator == _erc721a__msgSender()) revert ApproveToCaller();
 
-        _operatorApprovals[_msgSender()][operator] = approved;
-        emit ApprovalForAll(_msgSender(), operator, approved);
+        _operatorApprovals[_erc721a__msgSender()][operator] = approved;
+        emit ApprovalForAll(_erc721a__msgSender(), operator, approved);
     }
 
     /**
@@ -418,9 +418,9 @@ contract ERC721A is IERC721A {
 
         if (prevOwnership.addr != from) revert TransferFromIncorrectOwner();
 
-        bool isApprovedOrOwner = (_msgSender() == from ||
-            isApprovedForAll(from, _msgSender()) ||
-            getApproved(tokenId) == _msgSender());
+        bool isApprovedOrOwner = (_erc721a__msgSender() == from ||
+            isApprovedForAll(from, _erc721a__msgSender()) ||
+            getApproved(tokenId) == _erc721a__msgSender());
 
         if (!isApprovedOrOwner) revert TransferCallerNotOwnerNorApproved();
         if (to == address(0)) revert TransferToZeroAddress();
@@ -482,9 +482,9 @@ contract ERC721A is IERC721A {
         address from = prevOwnership.addr;
 
         if (approvalCheck) {
-            bool isApprovedOrOwner = (_msgSender() == from ||
-                isApprovedForAll(from, _msgSender()) ||
-                getApproved(tokenId) == _msgSender());
+            bool isApprovedOrOwner = (_erc721a__msgSender() == from ||
+                isApprovedForAll(from, _erc721a__msgSender()) ||
+                getApproved(tokenId) == _erc721a__msgSender());
 
             if (!isApprovedOrOwner) revert TransferCallerNotOwnerNorApproved();
         }
@@ -546,7 +546,7 @@ contract ERC721A is IERC721A {
         uint256 tokenId,
         bytes memory _data
     ) private returns (bool) {
-        try ERC721A__IERC721Receiver(to).onERC721Received(_msgSender(), from, tokenId, _data) 
+        try ERC721A__IERC721Receiver(to).onERC721Received(_erc721a__msgSender(), from, tokenId, _data) 
         returns (bytes4 retval) {
             return retval == ERC721A__IERC721Receiver(to).onERC721Received.selector;
         } catch (bytes memory reason) {
@@ -607,16 +607,11 @@ contract ERC721A is IERC721A {
 
     /**
      * @dev Returns the message sender (defaults to `msg.sender`).
+     * 
+     * If you are writing GSN compatible contracts, you need to override this function.
      */
-    function _msgSender() internal view virtual returns (address) {
+    function _erc721a__msgSender() internal view virtual returns (address) {
         return msg.sender;
-    }
-
-    /**
-     * @dev Returns the message data (defaults to `msg.data`).
-     */
-    function _msgData() internal view virtual returns (bytes calldata) {
-        return msg.data;
     }
 
     /**

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -217,7 +217,7 @@ contract ERC721A is IERC721A {
         address owner = ERC721A.ownerOf(tokenId);
         if (to == owner) revert ApprovalToCurrentOwner();
 
-        if (_erc721a__msgSender() != owner) if(!isApprovedForAll(owner, _erc721a__msgSender())) {
+        if (_erc721aMsgSender() != owner) if(!isApprovedForAll(owner, _erc721aMsgSender())) {
             revert ApprovalCallerNotOwnerNorApproved();
         }
 
@@ -238,10 +238,10 @@ contract ERC721A is IERC721A {
      * @dev See {IERC721-setApprovalForAll}.
      */
     function setApprovalForAll(address operator, bool approved) public virtual override {
-        if (operator == _erc721a__msgSender()) revert ApproveToCaller();
+        if (operator == _erc721aMsgSender()) revert ApproveToCaller();
 
-        _operatorApprovals[_erc721a__msgSender()][operator] = approved;
-        emit ApprovalForAll(_erc721a__msgSender(), operator, approved);
+        _operatorApprovals[_erc721aMsgSender()][operator] = approved;
+        emit ApprovalForAll(_erc721aMsgSender(), operator, approved);
     }
 
     /**
@@ -418,9 +418,9 @@ contract ERC721A is IERC721A {
 
         if (prevOwnership.addr != from) revert TransferFromIncorrectOwner();
 
-        bool isApprovedOrOwner = (_erc721a__msgSender() == from ||
-            isApprovedForAll(from, _erc721a__msgSender()) ||
-            getApproved(tokenId) == _erc721a__msgSender());
+        bool isApprovedOrOwner = (_erc721aMsgSender() == from ||
+            isApprovedForAll(from, _erc721aMsgSender()) ||
+            getApproved(tokenId) == _erc721aMsgSender());
 
         if (!isApprovedOrOwner) revert TransferCallerNotOwnerNorApproved();
         if (to == address(0)) revert TransferToZeroAddress();
@@ -482,9 +482,9 @@ contract ERC721A is IERC721A {
         address from = prevOwnership.addr;
 
         if (approvalCheck) {
-            bool isApprovedOrOwner = (_erc721a__msgSender() == from ||
-                isApprovedForAll(from, _erc721a__msgSender()) ||
-                getApproved(tokenId) == _erc721a__msgSender());
+            bool isApprovedOrOwner = (_erc721aMsgSender() == from ||
+                isApprovedForAll(from, _erc721aMsgSender()) ||
+                getApproved(tokenId) == _erc721aMsgSender());
 
             if (!isApprovedOrOwner) revert TransferCallerNotOwnerNorApproved();
         }
@@ -546,7 +546,7 @@ contract ERC721A is IERC721A {
         uint256 tokenId,
         bytes memory _data
     ) private returns (bool) {
-        try ERC721A__IERC721Receiver(to).onERC721Received(_erc721a__msgSender(), from, tokenId, _data) 
+        try ERC721A__IERC721Receiver(to).onERC721Received(_erc721aMsgSender(), from, tokenId, _data) 
         returns (bytes4 retval) {
             return retval == ERC721A__IERC721Receiver(to).onERC721Received.selector;
         } catch (bytes memory reason) {
@@ -610,7 +610,7 @@ contract ERC721A is IERC721A {
      * 
      * If you are writing GSN compatible contracts, you need to override this function.
      */
-    function _erc721a__msgSender() internal view virtual returns (address) {
+    function _erc721aMsgSender() internal view virtual returns (address) {
         return msg.sender;
     }
 


### PR DESCRIPTION
`_msgSender()` is used for writing GSN compatible contracts.

When users import OZ and inherit from their contracts (e.g. Ownable), our `_msgSender()` will conflict with their definition.

I suggest to keep an overrideable function, with a different name, such that it won't conflict.