### PR TITLE
Refactors

### DIFF
--- a/contracts/IERC721A.sol
+++ b/contracts/IERC721A.sol
@@ -73,7 +73,6 @@ interface IERC721A {
      */
     error URIQueryForNonexistentToken();
 
-    // Compiler will pack this into a single 256bit word.
     struct TokenOwnership {
         // The address of the owner.
         address addr;
@@ -81,20 +80,6 @@ interface IERC721A {
         uint64 startTimestamp;
         // Whether the token has been burned.
         bool burned;
-    }
-
-    // Compiler will pack this into a single 256bit word.
-    struct AddressData {
-        // Realistically, 2**64-1 is more than enough.
-        uint64 balance;
-        // Keeps track of mint count with minimal overhead for tokenomics.
-        uint64 numberMinted;
-        // Keeps track of burn count with minimal overhead for tokenomics.
-        uint64 numberBurned;
-        // For miscellaneous variable(s) pertaining to the address
-        // (e.g. number of whitelist mint slots used).
-        // If there are multiple variables, please pack them into a uint64.
-        uint64 aux;
     }
 
     /**

--- a/contracts/IERC721A.sol
+++ b/contracts/IERC721A.sol
@@ -84,7 +84,7 @@ interface IERC721A {
 
     /**
      * @dev Returns the total amount of tokens stored by the contract.
-     * 
+     *
      * Burned tokens are calculated here, use `_totalMinted()` if you want to count just minted tokens.
      */
     function totalSupply() external view returns (uint256);

--- a/contracts/extensions/ERC721AOwnersExplicit.sol
+++ b/contracts/extensions/ERC721AOwnersExplicit.sol
@@ -47,10 +47,11 @@ abstract contract ERC721AOwnersExplicit is ERC721A {
             }
 
             for (uint256 i = _nextOwnerToExplicitlySet; i <= endIndex; i++) {
-                if (_ownerships[i].addr == address(0) && !_ownerships[i].burned) {
+                uint256 packed = _packedOwnerships[i];
+                if (packed == 0) {
                     TokenOwnership memory ownership = _ownershipOf(i);
-                    _ownerships[i].addr = ownership.addr;
-                    _ownerships[i].startTimestamp = ownership.startTimestamp;
+                    _packedOwnerships[i] = (uint256(uint160(ownership.addr)) | 
+                        (uint256(ownership.startTimestamp) << 160));
                 }
             }
 

--- a/contracts/extensions/ERC721AOwnersExplicit.sol
+++ b/contracts/extensions/ERC721AOwnersExplicit.sol
@@ -10,52 +10,57 @@ abstract contract ERC721AOwnersExplicit is ERC721A {
     /**
      * No more ownership slots to explicity initialize.
      */
-    error AllOwnershipsHaveBeenSet();
-    
+    error AllOwnershipsInitialized();
+
     /**
      * The `quantity` must be more than zero.
      */
-    error QuantityMustBeNonZero();
-    
+    error InitializeZeroQuantity();
+
     /**
      * At least one token needs to be minted.
      */
     error NoTokensMintedYet();
 
-    uint256 public nextOwnerToExplicitlySet;
+    // The next token ID to explicity initialize ownership data.
+    uint256 private _currentIndexOwnersExplicit;
 
     /**
-     * @dev Explicitly set `owners` to eliminate loops in future calls of ownerOf().
+     * @dev Returns the next token ID to be explicity initialized.
      */
-    function _setOwnersExplicit(uint256 quantity) internal {
-        if (quantity == 0) revert QuantityMustBeNonZero();
-        if (_currentIndex == _startTokenId()) revert NoTokensMintedYet();
-        uint256 _nextOwnerToExplicitlySet = nextOwnerToExplicitlySet;
-        if (_nextOwnerToExplicitlySet == 0) {
-            _nextOwnerToExplicitlySet = _startTokenId();
+    function _nextTokenIdOwnersExplicit() internal view returns (uint256) {
+        uint256 tokenId = _currentIndexOwnersExplicit;
+        if (tokenId == 0) {
+            tokenId = _startTokenId();
         }
-        if (_nextOwnerToExplicitlySet >= _currentIndex) revert AllOwnershipsHaveBeenSet();
+        return tokenId;
+    }
+
+    /**
+     * @dev Explicitly initialize ownerships to eliminate loops in future calls of `ownerOf()`.
+     */
+    function _initializeOwnersExplicit(uint256 quantity) internal {
+        if (quantity == 0) revert InitializeZeroQuantity();
+        uint256 stopLimit = _nextTokenId();
+        if (stopLimit == _startTokenId()) revert NoTokensMintedYet();
+        uint256 start = _nextTokenIdOwnersExplicit();
+        if (start >= stopLimit) revert AllOwnershipsInitialized();
 
         // Index underflow is impossible.
         // Counter or index overflow is incredibly unrealistic.
         unchecked {
-            uint256 endIndex = _nextOwnerToExplicitlySet + quantity - 1;
+            uint256 stop = start + quantity;
 
             // Set the end index to be the last token index
-            if (endIndex + 1 > _currentIndex) {
-                endIndex = _currentIndex - 1;
+            if (stop > stopLimit) {
+                stop = stopLimit;
             }
 
-            for (uint256 i = _nextOwnerToExplicitlySet; i <= endIndex; i++) {
-                uint256 packed = _packedOwnerships[i];
-                if (packed == 0) {
-                    TokenOwnership memory ownership = _ownershipOf(i);
-                    _packedOwnerships[i] = (uint256(uint160(ownership.addr)) | 
-                        (uint256(ownership.startTimestamp) << 160));
-                }
+            for (uint256 i = start; i < stop; i++) {
+                _initializeOwnershipAt(i);
             }
 
-            nextOwnerToExplicitlySet = endIndex + 1;
+            _currentIndexOwnersExplicit = stop;
         }
     }
 }

--- a/contracts/extensions/ERC721AQueryable.sol
+++ b/contracts/extensions/ERC721AQueryable.sol
@@ -32,7 +32,7 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
      */
     function explicitOwnershipOf(uint256 tokenId) public view override returns (TokenOwnership memory) {
         TokenOwnership memory ownership;
-        if (tokenId < _startTokenId() || tokenId >= _currentIndex) {
+        if (tokenId < _startTokenId() || tokenId >= _nextTokenId()) {
             return ownership;
         }
         ownership = _ownershipAt(tokenId);
@@ -77,12 +77,12 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
         unchecked {
             if (start >= stop) revert InvalidQueryRange();
             uint256 tokenIdsIdx;
-            uint256 stopLimit = _currentIndex;
+            uint256 stopLimit = _nextTokenId();
             // Set `start = max(start, _startTokenId())`.
             if (start < _startTokenId()) {
                 start = _startTokenId();
             }
-            // Set `stop = min(stop, _currentIndex)`.
+            // Set `stop = min(stop, stopLimit)`.
             if (stop > stopLimit) {
                 stop = stopLimit;
             }

--- a/contracts/extensions/ERC721AQueryable.sol
+++ b/contracts/extensions/ERC721AQueryable.sol
@@ -35,7 +35,7 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
         if (tokenId < _startTokenId() || tokenId >= _currentIndex) {
             return ownership;
         }
-        ownership = _ownerships[tokenId];
+        ownership = _ownershipAt(tokenId);
         if (ownership.burned) {
             return ownership;
         }
@@ -111,7 +111,7 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
                 currOwnershipAddr = ownership.addr;
             }
             for (uint256 i = start; i != stop && tokenIdsIdx != tokenIdsMaxLength; ++i) {
-                ownership = _ownerships[i];
+                ownership = _ownershipAt(i);
                 if (ownership.burned) {
                     continue;
                 }
@@ -148,7 +148,7 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
             uint256[] memory tokenIds = new uint256[](tokenIdsLength);
             TokenOwnership memory ownership;
             for (uint256 i = _startTokenId(); tokenIdsIdx != tokenIdsLength; ++i) {
-                ownership = _ownerships[i];
+                ownership = _ownershipAt(i);
                 if (ownership.burned) {
                     continue;
                 }

--- a/contracts/mocks/ERC721ABurnableMock.sol
+++ b/contracts/mocks/ERC721ABurnableMock.sol
@@ -18,7 +18,7 @@ contract ERC721ABurnableMock is ERC721A, ERC721ABurnable {
     }
 
     function getOwnershipAt(uint256 index) public view returns (TokenOwnership memory) {
-        return _ownerships[index];
+        return _ownershipAt(index);
     }
 
     function totalMinted() public view returns (uint256) {

--- a/contracts/mocks/ERC721ABurnableMock.sol
+++ b/contracts/mocks/ERC721ABurnableMock.sol
@@ -24,4 +24,8 @@ contract ERC721ABurnableMock is ERC721A, ERC721ABurnable {
     function totalMinted() public view returns (uint256) {
         return _totalMinted();
     }
+
+    function numberBurned(address owner) public view returns (uint256) {
+        return _numberBurned(owner);
+    }
 }

--- a/contracts/mocks/ERC721ABurnableOwnersExplicitMock.sol
+++ b/contracts/mocks/ERC721ABurnableOwnersExplicitMock.sol
@@ -18,8 +18,8 @@ contract ERC721ABurnableOwnersExplicitMock is ERC721A, ERC721ABurnable, ERC721AO
         _safeMint(to, quantity);
     }
 
-    function setOwnersExplicit(uint256 quantity) public {
-        _setOwnersExplicit(quantity);
+    function initializeOwnersExplicit(uint256 quantity) public {
+        _initializeOwnersExplicit(quantity);
     }
 
     function getOwnershipAt(uint256 index) public view returns (TokenOwnership memory) {

--- a/contracts/mocks/ERC721ABurnableOwnersExplicitMock.sol
+++ b/contracts/mocks/ERC721ABurnableOwnersExplicitMock.sol
@@ -23,6 +23,6 @@ contract ERC721ABurnableOwnersExplicitMock is ERC721A, ERC721ABurnable, ERC721AO
     }
 
     function getOwnershipAt(uint256 index) public view returns (TokenOwnership memory) {
-        return _ownerships[index];
+        return _ownershipAt(index);
     }
 }

--- a/contracts/mocks/ERC721AMock.sol
+++ b/contracts/mocks/ERC721AMock.sol
@@ -56,4 +56,8 @@ contract ERC721AMock is ERC721A {
     function toString(uint256 x) public pure returns (string memory) {
         return _toString(x);
     }
+
+    function getOwnershipAt(uint256 index) public view returns (TokenOwnership memory) {
+        return _ownershipAt(index);
+    }
 }

--- a/contracts/mocks/ERC721AOwnersExplicitMock.sol
+++ b/contracts/mocks/ERC721AOwnersExplicitMock.sol
@@ -13,11 +13,15 @@ contract ERC721AOwnersExplicitMock is ERC721AOwnersExplicit {
         _safeMint(to, quantity);
     }
 
-    function setOwnersExplicit(uint256 quantity) public {
-        _setOwnersExplicit(quantity);
+    function initializeOwnersExplicit(uint256 quantity) public {
+        _initializeOwnersExplicit(quantity);
     }
 
     function getOwnershipAt(uint256 index) public view returns (TokenOwnership memory) {
         return _ownershipAt(index);
+    }
+
+    function nextTokenIdOwnersExplicit() public view returns (uint256) {
+        return _nextTokenIdOwnersExplicit();
     }
 }

--- a/contracts/mocks/ERC721AOwnersExplicitMock.sol
+++ b/contracts/mocks/ERC721AOwnersExplicitMock.sol
@@ -17,7 +17,7 @@ contract ERC721AOwnersExplicitMock is ERC721AOwnersExplicit {
         _setOwnersExplicit(quantity);
     }
 
-    function getOwnershipAt(uint256 tokenId) public view returns (TokenOwnership memory) {
-        return _ownerships[tokenId];
+    function getOwnershipAt(uint256 index) public view returns (TokenOwnership memory) {
+        return _ownershipAt(index);
     }
 }

--- a/contracts/mocks/ERC721AQueryableOwnersExplicitMock.sol
+++ b/contracts/mocks/ERC721AQueryableOwnersExplicitMock.sol
@@ -15,6 +15,6 @@ contract ERC721AQueryableOwnersExplicitMock is ERC721AQueryableMock, ERC721AOwne
     }
 
     function getOwnershipAt(uint256 index) public view returns (TokenOwnership memory) {
-        return _ownerships[index];
+        return _ownershipAt(index);
     }
 }

--- a/contracts/mocks/ERC721AQueryableOwnersExplicitMock.sol
+++ b/contracts/mocks/ERC721AQueryableOwnersExplicitMock.sol
@@ -10,8 +10,8 @@ import '../extensions/ERC721AOwnersExplicit.sol';
 contract ERC721AQueryableOwnersExplicitMock is ERC721AQueryableMock, ERC721AOwnersExplicit {
     constructor(string memory name_, string memory symbol_) ERC721AQueryableMock(name_, symbol_) {}
 
-    function setOwnersExplicit(uint256 quantity) public {
-        _setOwnersExplicit(quantity);
+    function initializeOwnersExplicit(uint256 quantity) public {
+        _initializeOwnersExplicit(quantity);
     }
 
     function getOwnershipAt(uint256 index) public view returns (TokenOwnership memory) {

--- a/test/GasUsage.test.js
+++ b/test/GasUsage.test.js
@@ -39,4 +39,15 @@ describe('ERC721A Gas Usage', function () {
       }
     });
   });
+
+  context('transferFrom', function () {
+    it('transfer to and from two addresses', async function () {
+      await this.erc721a.mintTen(this.addr1.address);
+      await this.erc721a.mintTen(this.owner.address);
+      for (let i = 0; i < 10; ++i) {
+        await this.erc721a.connect(this.addr1).transferFrom(this.addr1.address, this.owner.address, 1);
+        await this.erc721a.connect(this.owner).transferFrom(this.owner.address, this.addr1.address, 1);
+      }  
+    });
+  });
 });

--- a/test/extensions/ERC721ABurnableOwnersExplicit.test.js
+++ b/test/extensions/ERC721ABurnableOwnersExplicit.test.js
@@ -19,10 +19,10 @@ describe('ERC721ABurnableOwnersExplicit', function () {
     await this.token['safeMint(address,uint256)'](addr3.address, 3);
     await this.token.connect(this.addr1).burn(0);
     await this.token.connect(this.addr3).burn(4);
-    await this.token.setOwnersExplicit(6);
+    await this.token.initializeOwnersExplicit(6);
   });
 
-  it('ownerships correctly set', async function () {
+  it('ownerships correctly initialized', async function () {
     for (let tokenId = 0; tokenId < 6; tokenId++) {
       let owner = await this.token.getOwnershipAt(tokenId);
       expect(owner[0]).to.not.equal(ZERO_ADDRESS);

--- a/test/extensions/ERC721AOwnersExplicit.test.js
+++ b/test/extensions/ERC721AOwnersExplicit.test.js
@@ -1,4 +1,4 @@
-const { deployContract } = require('../helpers.js');
+const { deployContract, getBlockTimestamp, mineBlockTimestamp } = require('../helpers.js');
 const { expect } = require('chai');
 const { constants } = require('@openzeppelin/test-helpers');
 const { ZERO_ADDRESS } = constants;
@@ -16,7 +16,9 @@ const createTestSuite = ({ contract, constructorArgs }) =>
 
       context('with no minted tokens', async function () {
         it('does not have enough tokens minted', async function () {
-          await expect(this.erc721aOwnersExplicit.setOwnersExplicit(1)).to.be.revertedWith('NoTokensMintedYet');
+          await expect(this.erc721aOwnersExplicit.initializeOwnersExplicit(1)).to.be.revertedWith(
+            'NoTokensMintedYet'
+          );
         });
       });
 
@@ -27,6 +29,12 @@ const createTestSuite = ({ contract, constructorArgs }) =>
           this.addr1 = addr1;
           this.addr2 = addr2;
           this.addr3 = addr3;
+
+          this.timestampBefore = await getBlockTimestamp();
+          this.timestampToMine = (this.timestampBefore) + 100;
+          await mineBlockTimestamp(this.timestampToMine);
+          this.timestampMined = await getBlockTimestamp();
+
           // After the following mints, our ownership array will look like this:
           // | 1 | 2 | Empty | 3 | Empty | Empty |
           await this.erc721aOwnersExplicit['safeMint(address,uint256)'](addr1.address, 1);
@@ -34,66 +42,78 @@ const createTestSuite = ({ contract, constructorArgs }) =>
           await this.erc721aOwnersExplicit['safeMint(address,uint256)'](addr3.address, 3);
         });
 
-        describe('setOwnersExplicit', async function () {
+        describe('initializeOwnersExplicit', async function () {
           it('rejects 0 quantity', async function () {
-            await expect(this.erc721aOwnersExplicit.setOwnersExplicit(0)).to.be.revertedWith('QuantityMustBeNonZero');
+            await expect(this.erc721aOwnersExplicit.initializeOwnersExplicit(0)).to.be.revertedWith(
+              'InitializeZeroQuantity'
+            );
           });
 
           it('handles single increment properly', async function () {
-            await this.erc721aOwnersExplicit.setOwnersExplicit(1);
-            expect(await this.erc721aOwnersExplicit.nextOwnerToExplicitlySet()).to.equal(
+            await this.erc721aOwnersExplicit.initializeOwnersExplicit(1);
+            expect(await this.erc721aOwnersExplicit.nextTokenIdOwnersExplicit()).to.equal(
               (1 + this.startTokenId).toString()
             );
           });
 
-          it('properly sets the ownership of index 2', async function () {
+          it('properly initializes the ownership of index 2', async function () {
             let ownerAtTwo = await this.erc721aOwnersExplicit.getOwnershipAt(2 + this.startTokenId);
             expect(ownerAtTwo[0]).to.equal(ZERO_ADDRESS);
-            await this.erc721aOwnersExplicit.setOwnersExplicit(3);
+            await this.erc721aOwnersExplicit.initializeOwnersExplicit(3);
             ownerAtTwo = await this.erc721aOwnersExplicit.getOwnershipAt(2);
             expect(ownerAtTwo[0]).to.equal(this.addr2.address);
-            expect(await this.erc721aOwnersExplicit.nextOwnerToExplicitlySet()).to.equal(
+            expect(await this.erc721aOwnersExplicit.nextTokenIdOwnersExplicit()).to.equal(
               (3 + this.startTokenId).toString()
             );
           });
 
-          it('sets all ownerships in one go', async function () {
-            await this.erc721aOwnersExplicit.setOwnersExplicit(6);
+          it('initializes all ownerships in one go', async function () {
+            await this.erc721aOwnersExplicit.initializeOwnersExplicit(6);
             for (let tokenId = this.startTokenId; tokenId < 6 + this.startTokenId; tokenId++) {
               let owner = await this.erc721aOwnersExplicit.getOwnershipAt(tokenId);
               expect(owner[0]).to.not.equal(ZERO_ADDRESS);
             }
           });
 
-          it('sets all ownerships with overflowing quantity', async function () {
-            await this.erc721aOwnersExplicit.setOwnersExplicit(15);
+          it('initializes all ownerships with overflowing quantity', async function () {
+            await this.erc721aOwnersExplicit.initializeOwnersExplicit(15);
             for (let tokenId = this.startTokenId; tokenId < 6 + this.startTokenId; tokenId++) {
               let owner = await this.erc721aOwnersExplicit.getOwnershipAt(tokenId);
               expect(owner[0]).to.not.equal(ZERO_ADDRESS);
             }
           });
 
-          it('sets all ownerships in multiple calls', async function () {
-            await this.erc721aOwnersExplicit.setOwnersExplicit(2);
-            expect(await this.erc721aOwnersExplicit.nextOwnerToExplicitlySet()).to.equal(
+          it('initializes all ownerships in multiple calls', async function () {
+            await this.erc721aOwnersExplicit.initializeOwnersExplicit(2);
+            expect(await this.erc721aOwnersExplicit.nextTokenIdOwnersExplicit()).to.equal(
               (2 + this.startTokenId).toString()
             );
-            await this.erc721aOwnersExplicit.setOwnersExplicit(1);
-            expect(await this.erc721aOwnersExplicit.nextOwnerToExplicitlySet()).to.equal(
+            await this.erc721aOwnersExplicit.initializeOwnersExplicit(1);
+            expect(await this.erc721aOwnersExplicit.nextTokenIdOwnersExplicit()).to.equal(
               (3 + this.startTokenId).toString()
             );
-            await this.erc721aOwnersExplicit.setOwnersExplicit(3);
+            await this.erc721aOwnersExplicit.initializeOwnersExplicit(3);
             for (let tokenId = this.startTokenId; tokenId < 6 + this.startTokenId; tokenId++) {
               let owner = await this.erc721aOwnersExplicit.getOwnershipAt(tokenId);
               expect(owner[0]).to.not.equal(ZERO_ADDRESS);
             }
           });
 
-          it('rejects after all ownerships have been set', async function () {
-            await this.erc721aOwnersExplicit.setOwnersExplicit(6);
-            await expect(this.erc721aOwnersExplicit.setOwnersExplicit(1)).to.be.revertedWith(
-              'AllOwnershipsHaveBeenSet'
+          it('rejects after all ownerships have been initialized', async function () {
+            await this.erc721aOwnersExplicit.initializeOwnersExplicit(6);
+            await expect(this.erc721aOwnersExplicit.initializeOwnersExplicit(1)).to.be.revertedWith(
+              'AllOwnershipsInitialized'
             );
+          });
+
+          it('initializes startTimestamps correctly', async function () {
+            await this.erc721aOwnersExplicit.initializeOwnersExplicit(6);
+            expect(this.timestampToMine).to.be.eq(this.timestampMined);
+            for (let tokenId = this.startTokenId; tokenId < 6 + this.startTokenId; tokenId++) {
+              let owner = await this.erc721aOwnersExplicit.getOwnershipAt(tokenId);
+              expect(owner.startTimestamp).to.be.gt(this.timestampBefore);
+              expect(owner.startTimestamp).to.be.gte(this.timestampToMine);
+            }
           });
         });
       });

--- a/test/extensions/ERC721AQueryable.test.js
+++ b/test/extensions/ERC721AQueryable.test.js
@@ -252,8 +252,8 @@ const createTestSuite = ({ contract, constructorArgs, setOwnersExplicit = false 
             const tokenIds = [].concat(this.owner.expected.tokens, this.addr3.expected.tokens);
             const explicitOwnerships = await this.erc721aQueryable.explicitOwnershipsOf(tokenIds);
             for (let i = 0; i < tokenIds.length; ++i) {
-              const tokenId = await this.erc721aQueryable.ownerOf(tokenIds[i]);
-              expectExplicitOwnershipExists(explicitOwnerships[i], tokenId);
+              const owner = await this.erc721aQueryable.ownerOf(tokenIds[i]);
+              expectExplicitOwnershipExists(explicitOwnerships[i], owner);
             }
           });
 
@@ -263,8 +263,8 @@ const createTestSuite = ({ contract, constructorArgs, setOwnersExplicit = false 
             const explicitOwnerships = await this.erc721aQueryable.explicitOwnershipsOf(tokenIds);
             expectExplicitOwnershipBurned(explicitOwnerships[0], this.owner.address);
             for (let i = 1; i < tokenIds.length; ++i) {
-              const tokenId = await this.erc721aQueryable.ownerOf(tokenIds[i]);
-              expectExplicitOwnershipExists(explicitOwnerships[i], tokenId);
+              const owner = await this.erc721aQueryable.ownerOf(tokenIds[i]);
+              expectExplicitOwnershipExists(explicitOwnerships[i], owner);
             }
           });
 
@@ -274,8 +274,8 @@ const createTestSuite = ({ contract, constructorArgs, setOwnersExplicit = false 
             const explicitOwnerships = await this.erc721aQueryable.explicitOwnershipsOf(tokenIds);
             expectExplicitOwnershipExists(explicitOwnerships[0], this.addr4.address);
             for (let i = 1; i < tokenIds.length; ++i) {
-              const tokenId = await this.erc721aQueryable.ownerOf(tokenIds[i]);
-              expectExplicitOwnershipExists(explicitOwnerships[i], tokenId);
+              const owner = await this.erc721aQueryable.ownerOf(tokenIds[i]);
+              expectExplicitOwnershipExists(explicitOwnerships[i], owner);
             }
           });
 
@@ -284,8 +284,8 @@ const createTestSuite = ({ contract, constructorArgs, setOwnersExplicit = false 
             const explicitOwnerships = await this.erc721aQueryable.explicitOwnershipsOf(tokenIds);
             expectExplicitOwnershipNotExists(explicitOwnerships[0]);
             for (let i = 1; i < tokenIds.length; ++i) {
-              const tokenId = await this.erc721aQueryable.ownerOf(tokenIds[i]);
-              expectExplicitOwnershipExists(explicitOwnerships[i], tokenId);
+              const owner = await this.erc721aQueryable.ownerOf(tokenIds[i]);
+              expectExplicitOwnershipExists(explicitOwnerships[i], owner);
             }
           });
         });

--- a/test/extensions/ERC721AQueryable.test.js
+++ b/test/extensions/ERC721AQueryable.test.js
@@ -4,7 +4,7 @@ const { BigNumber } = require('ethers');
 const { constants } = require('@openzeppelin/test-helpers');
 const { ZERO_ADDRESS } = constants;
 
-const createTestSuite = ({ contract, constructorArgs, setOwnersExplicit = false }) =>
+const createTestSuite = ({ contract, constructorArgs, initializeOwnersExplicit = false }) =>
   function () {
     let offseted;
 
@@ -123,10 +123,10 @@ const createTestSuite = ({ contract, constructorArgs, setOwnersExplicit = false 
             expect(await this.erc721aQueryable.balanceOf(minter.address)).to.equal(minter.expected.balance);
           }
 
-          if (setOwnersExplicit) {
+          if (initializeOwnersExplicit) {
             // sanity check
             expect((await this.erc721aQueryable.getOwnershipAt(offseted(4)[0]))[0]).to.equal(ZERO_ADDRESS);
-            await this.erc721aQueryable.setOwnersExplicit(10);
+            await this.erc721aQueryable.initializeOwnersExplicit(10);
             // again, sanity check
             expect((await this.erc721aQueryable.getOwnershipAt(offseted(4)[0]))[0]).to.equal(this.addr3.address);
           }
@@ -311,6 +311,6 @@ describe(
   createTestSuite({
     contract: 'ERC721AQueryableOwnersExplicitMock',
     constructorArgs: ['Azuki', 'AZUKI'],
-    setOwnersExplicit: true,
+    initializeOwnersExplicit: true,
   })
 );

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -12,4 +12,13 @@ const deployContract = async function (contractName, constructorArgs) {
   return contract;
 };
 
-module.exports = { deployContract };
+const getBlockTimestamp = async function () {
+  return parseInt((await ethers.provider.getBlock('latest'))['timestamp']);
+};
+
+const mineBlockTimestamp = async function (timestamp) {
+  await ethers.provider.send('evm_setNextBlockTimestamp', [timestamp]);
+  await ethers.provider.send('evm_mine');
+};
+
+module.exports = { deployContract, getBlockTimestamp, mineBlockTimestamp };


### PR DESCRIPTION
This PR is planned to be merged after #272.

- `contracts/ERC721A.sol`:
  - Variable `_currentIndex` made private.   
    - Created `_nextTokenId()` internal view function to return the value instead.
  - Variable `_burnCounter` made private.  
    - Created `_totalBurned()` internal view function to return the value instead.
    
 Making these variables private and wrapping them in internal view functions makes them read-only. 
 
 This is intended, since devs are NOT supposed to directly edit these values.
 
 It also makes their names more consistent with the functions `_totalMinted()` and `_startTokenId()`.
 
 Also, this will make it easier to read their values in Diamond upgradeables 
 (users can simply call `_totalBurned()` instead of `ERC721AUpgradable.storage()._burnCounter`). 
  
- `contracts/extensions/ERC721AOwnersExplicit.sol`
  - Error `QuantityMustBeNonZero` renamed to `InitializeZeroQuantity` for consistency with errors in `IERC721A.sol` (e.g. `MintZeroQuantity`).
  - Error `AllOwnershipsHaveBeenSet` renamed to `AllOwnershipsInitialized`.
  - `nextOwnerToExplicitlySet` renamed to `_currentIndexOwnersExplicit` and made private for consistency with variables in `ERC721A.sol`.
    - Created `_nextTokenIdOwnersExplicit()` internal view function to return the value instead.
  - Renamed `_setOwnersExplicit` to `_initializeOwnersExplicit` to keep consistency with function `_initializeOwnershipAt` in `ERC721A.sol`.
  
Semantically, "initialize" is a better word than "set" for their use case, since users cannot decide on the value.