### PR TITLE
Assembly for _toString

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -758,11 +758,10 @@ contract ERC721A is IERC721A {
      */
     function _toString(uint256 value) internal pure returns (string memory ptr) {
         assembly {
-            // The maximum value of a uint256 contains 78 digits, 
+            // The maximum value of a uint256 contains 78 digits (1 byte per digit), 
             // but we allocate 128 bytes to keep the free memory pointer 32-byte word aliged.
-            // 128 = 32 + 3 * 32. 
-            // We need a minimal of 3 32-byte words to store 78 digits, 
-            // and 1 more 32-byte word to store the length. 
+            // We will need 1 32-byte word to store the length, 
+            // and 3 32-byte words to store a maximum of 78 digits. Total: 32 + 3 * 32 = 128.
             ptr := add(mload(0x40), 128)
             // Update the free memory pointer to allocate.
             mstore(0x40, ptr)
@@ -772,26 +771,26 @@ contract ERC721A is IERC721A {
 
             // We write the string from rightmost digit to leftmost digit.
             // The following is essentially a do-while loop that also handles the zero case.
-            // Costs a bit more vs early return for the zero case, 
-            // but otherwise cheaper in terms of deployment and overall runtime costs.
+            // Costs a bit more than early returning for the zero case,
+            // but cheaper in terms of deployment and runtime costs.
             for { 
                 // Initialize and perform the first pass without check.
                 let temp := value
+                // Move the pointer 1 byte leftwards to point to an empty character slot.
                 ptr := sub(ptr, 1)
-                // Write the character to the pointer.
-                // 48 is the ASCII index of '0'.
+                // Write the character to the pointer. 48 is the ASCII index of '0'.
                 mstore8(ptr, add(48, mod(temp, 10)))
                 temp := div(temp, 10)
             } temp { 
                 // Keep dividing temp until zero.
-                temp := div(temp, 10) 
-            } { 
+                temp := div(temp, 10)
+            } { // Body of the for loop.
                 ptr := sub(ptr, 1)
                 mstore8(ptr, add(48, mod(temp, 10)))
             }
-
+            
             let length := sub(end, ptr)
-            // Move the pointer 32 bytes lower to make room for the length.
+            // Move the pointer 32 bytes leftwards to make room for the length.
             ptr := sub(ptr, 32)
             // Store the length.
             mstore(ptr, length)

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -774,17 +774,20 @@ contract ERC721A is IERC721A {
             // The following is essentially a do-while loop that also handles the zero case.
             // Costs a bit more vs early return for the zero case, 
             // but otherwise cheaper in terms of deployment and overall runtime costs.
-            let temp := value
-            ptr := sub(ptr, 1)
-            // Write the character to the pointer.
-            // 48 is the ASCII index of '0'.
-            mstore8(ptr, add(48, mod(temp, 10))) 
-            temp := div(temp, 10)
-
-            for {} temp {} {
+            for { 
+                // Initialize and perform the first pass without check.
+                let temp := value
                 ptr := sub(ptr, 1)
+                // Write the character to the pointer.
+                // 48 is the ASCII index of '0'.
                 mstore8(ptr, add(48, mod(temp, 10)))
                 temp := div(temp, 10)
+            } temp { 
+                // Keep dividing temp until zero.
+                temp := div(temp, 10) 
+            } { 
+                ptr := sub(ptr, 1)
+                mstore8(ptr, add(48, mod(temp, 10)))
             }
 
             let length := sub(end, ptr)

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -631,12 +631,16 @@ contract ERC721A is IERC721A {
             let end := ptr
             
             // We write the string from rightmost digit to leftmost digit.
-            // This is essentially a do-while loop that also handles the zero case.
-            // Costs a bit more vs early return for the zero case, but otherwise cheaper.
+            // The following essentially a do-while loop that also handles the zero case.
+            // Costs a bit more vs early return for the zero case, 
+            // but otherwise cheaper in terms of deployment and overall runtime costs.
             let temp := value
             ptr := sub(ptr, 1)
-            mstore8(ptr, add(48, mod(temp, 10))) // 48 is the ASCII index of '0'.
+            // Write the character to the pointer.
+            // 48 is the ASCII index of '0'.
+            mstore8(ptr, add(48, mod(temp, 10))) 
             temp := div(temp, 10)
+            
             for {} temp {} {
                 ptr := sub(ptr, 1)
                 mstore8(ptr, add(48, mod(temp, 10)))

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -769,7 +769,7 @@ contract ERC721A is IERC721A {
             // Cache the end of the memory to calculate the length later.
             let end := ptr
 
-            // We write the string from rightmost digit to leftmost digit.
+            // We write the string from the rightmost digit to the leftmost digit.
             // The following is essentially a do-while loop that also handles the zero case.
             // Costs a bit more than early returning for the zero case,
             // but cheaper in terms of deployment and runtime costs.
@@ -782,7 +782,7 @@ contract ERC721A is IERC721A {
                 mstore8(ptr, add(48, mod(temp, 10)))
                 temp := div(temp, 10)
             } temp { 
-                // Keep dividing temp until zero.
+                // Keep dividing `temp` until zero.
                 temp := div(temp, 10)
             } { // Body of the for loop.
                 ptr := sub(ptr, 1)

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -772,7 +772,7 @@ contract ERC721A is IERC721A {
             // We write the string from the rightmost digit to the leftmost digit.
             // The following is essentially a do-while loop that also handles the zero case.
             // Costs a bit more than early returning for the zero case,
-            // but cheaper in terms of deployment and runtime costs.
+            // but cheaper in terms of deployment and overall runtime costs.
             for { 
                 // Initialize and perform the first pass without check.
                 let temp := value

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -632,7 +632,7 @@ contract ERC721A is IERC721A {
             let end := ptr
             
             // We write the string from rightmost digit to leftmost digit.
-            // The following essentially a do-while loop that also handles the zero case.
+            // The following is essentially a do-while loop that also handles the zero case.
             // Costs a bit more vs early return for the zero case, 
             // but otherwise cheaper in terms of deployment and overall runtime costs.
             let temp := value

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -622,7 +622,8 @@ contract ERC721A is IERC721A {
             // The maximum value of a uint256 contains 78 digits, 
             // but we allocate 128 bytes to keep the free memory pointer 32-byte word aliged.
             // 128 = 32 + 3 * 32. 
-            // We need a minimal of 3 32-byte words to store 78 digits. 
+            // We need a minimal of 3 32-byte words to store 78 digits, 
+            // and 1 more 32-byte word to store the length. 
             let ptr := add(mload(0x40), 128)
             // Update the free memory pointer to allocate.
             mstore(0x40, ptr)

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -643,11 +643,11 @@ contract ERC721A is IERC721A {
                 temp := div(temp, 10)
             }
 
-            temp := sub(end, ptr)
+            let length := sub(end, ptr)
             // Move the pointer 32 bytes lower to make room for the length.
             ptr := sub(ptr, 32)
             // Store the length.
-            mstore(ptr, temp)
+            mstore(ptr, length)
             // Assign the string's memory location to the result.
             result := ptr
         }

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -617,20 +617,20 @@ contract ERC721A is IERC721A {
     /**
      * @dev Converts a `uint256` to its ASCII `string` decimal representation.
      */
-    function _toString(uint256 value) internal pure returns (string memory result) {
+    function _toString(uint256 value) internal pure returns (string memory ptr) {
         assembly {
             // The maximum value of a uint256 contains 78 digits, 
             // but we allocate 128 bytes to keep the free memory pointer 32-byte word aliged.
             // 128 = 32 + 3 * 32. 
             // We need a minimal of 3 32-byte words to store 78 digits, 
             // and 1 more 32-byte word to store the length. 
-            let ptr := add(mload(0x40), 128)
+            ptr := add(mload(0x40), 128)
             // Update the free memory pointer to allocate.
             mstore(0x40, ptr)
 
             // Cache the end of the memory to calculate the length later.
             let end := ptr
-            
+
             // We write the string from rightmost digit to leftmost digit.
             // The following is essentially a do-while loop that also handles the zero case.
             // Costs a bit more vs early return for the zero case, 
@@ -641,7 +641,7 @@ contract ERC721A is IERC721A {
             // 48 is the ASCII index of '0'.
             mstore8(ptr, add(48, mod(temp, 10))) 
             temp := div(temp, 10)
-            
+
             for {} temp {} {
                 ptr := sub(ptr, 1)
                 mstore8(ptr, add(48, mod(temp, 10)))
@@ -653,8 +653,6 @@ contract ERC721A is IERC721A {
             ptr := sub(ptr, 32)
             // Store the length.
             mstore(ptr, length)
-            // Assign the string's memory location to the result.
-            result := ptr
         }
     }
 }


### PR DESCRIPTION
For lower deployment and runtime gas, and remove need to import other libraries for similar functionality. 

For an isolated pure function, we can afford putting in more cool tricks. 

Most importantly, it looks dope shit.