### PR TITLE
Name changes and read-only wrappers for consistency

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -57,10 +57,10 @@ contract ERC721A is IERC721A {
     uint256 private constant BITMASK_NEXT_INITIALIZED = 1 << 225;
 
     // The tokenId of the next token to be minted.
-    uint256 internal _currentIndex;
+    uint256 private _currentIndex;
 
     // The number of tokens burned.
-    uint256 internal _burnCounter;
+    uint256 private _burnCounter;
 
     // Token name
     string private _name;
@@ -101,32 +101,49 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * To change the starting tokenId, please override this function.
+     * @dev Returns the starting token ID. 
+     * To change the starting token ID, please override this function.
      */
     function _startTokenId() internal view virtual returns (uint256) {
         return 0;
     }
 
     /**
-     * @dev Burned tokens are calculated here, use _totalMinted() if you want to count just minted tokens.
+     * @dev Returns the next token ID to be minted.
+     */
+    function _nextTokenId() internal view returns (uint256) {
+        return _currentIndex;
+    }
+
+    /**
+     * @dev Returns the total number of tokens in existence.
+     * Burned tokens will reduce the count. 
+     * To get the total number of tokens minted, please see `_totalMinted`.
      */
     function totalSupply() public view override returns (uint256) {
         // Counter underflow is impossible as _burnCounter cannot be incremented
-        // more than _currentIndex - _startTokenId() times
+        // more than `_currentIndex - _startTokenId()` times.
         unchecked {
             return _currentIndex - _burnCounter - _startTokenId();
         }
     }
 
     /**
-     * Returns the total amount of tokens minted in the contract.
+     * @dev Returns the total amount of tokens minted in the contract.
      */
     function _totalMinted() internal view returns (uint256) {
         // Counter underflow is impossible as _currentIndex does not decrement,
-        // and it is initialized to _startTokenId()
+        // and it is initialized to `_startTokenId()`
         unchecked {
             return _currentIndex - _startTokenId();
         }
+    }
+
+    /**
+     * @dev Returns the total number of tokens burned.
+     */
+    function _totalBurned() internal view returns (uint256) {
+        return _burnCounter;
     }
 
     /**

--- a/contracts/extensions/ERC721AQueryable.sol
+++ b/contracts/extensions/ERC721AQueryable.sol
@@ -32,7 +32,7 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
      */
     function explicitOwnershipOf(uint256 tokenId) public view override returns (TokenOwnership memory) {
         TokenOwnership memory ownership;
-        if (tokenId < _startTokenId() || tokenId >= _currentIndex) {
+        if (tokenId < _startTokenId() || tokenId >= _nextTokenId()) {
             return ownership;
         }
         ownership = _ownershipAt(tokenId);
@@ -77,12 +77,12 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
         unchecked {
             if (start >= stop) revert InvalidQueryRange();
             uint256 tokenIdsIdx;
-            uint256 stopLimit = _currentIndex;
+            uint256 stopLimit = _nextTokenId();
             // Set `start = max(start, _startTokenId())`.
             if (start < _startTokenId()) {
                 start = _startTokenId();
             }
-            // Set `stop = min(stop, _currentIndex)`.
+            // Set `stop = min(stop, stopLimit)`.
             if (stop > stopLimit) {
                 stop = stopLimit;
             }

--- a/contracts/mocks/ERC721ABurnableOwnersExplicitMock.sol
+++ b/contracts/mocks/ERC721ABurnableOwnersExplicitMock.sol
@@ -18,8 +18,8 @@ contract ERC721ABurnableOwnersExplicitMock is ERC721A, ERC721ABurnable, ERC721AO
         _safeMint(to, quantity);
     }
 
-    function setOwnersExplicit(uint256 quantity) public {
-        _setOwnersExplicit(quantity);
+    function initializeOwnersExplicit(uint256 quantity) public {
+        _initializeOwnersExplicit(quantity);
     }
 
     function getOwnershipAt(uint256 index) public view returns (TokenOwnership memory) {

--- a/contracts/mocks/ERC721AOwnersExplicitMock.sol
+++ b/contracts/mocks/ERC721AOwnersExplicitMock.sol
@@ -13,11 +13,15 @@ contract ERC721AOwnersExplicitMock is ERC721AOwnersExplicit {
         _safeMint(to, quantity);
     }
 
-    function setOwnersExplicit(uint256 quantity) public {
-        _setOwnersExplicit(quantity);
+    function initializeOwnersExplicit(uint256 quantity) public {
+        _initializeOwnersExplicit(quantity);
     }
 
     function getOwnershipAt(uint256 index) public view returns (TokenOwnership memory) {
         return _ownershipAt(index);
+    }
+
+    function nextTokenIdOwnersExplicit() public view returns (uint256) {
+        return _nextTokenIdOwnersExplicit();
     }
 }

--- a/contracts/mocks/ERC721AQueryableOwnersExplicitMock.sol
+++ b/contracts/mocks/ERC721AQueryableOwnersExplicitMock.sol
@@ -10,8 +10,8 @@ import '../extensions/ERC721AOwnersExplicit.sol';
 contract ERC721AQueryableOwnersExplicitMock is ERC721AQueryableMock, ERC721AOwnersExplicit {
     constructor(string memory name_, string memory symbol_) ERC721AQueryableMock(name_, symbol_) {}
 
-    function setOwnersExplicit(uint256 quantity) public {
-        _setOwnersExplicit(quantity);
+    function initializeOwnersExplicit(uint256 quantity) public {
+        _initializeOwnersExplicit(quantity);
     }
 
     function getOwnershipAt(uint256 index) public view returns (TokenOwnership memory) {

--- a/test/extensions/ERC721ABurnableOwnersExplicit.test.js
+++ b/test/extensions/ERC721ABurnableOwnersExplicit.test.js
@@ -19,10 +19,10 @@ describe('ERC721ABurnableOwnersExplicit', function () {
     await this.token['safeMint(address,uint256)'](addr3.address, 3);
     await this.token.connect(this.addr1).burn(0);
     await this.token.connect(this.addr3).burn(4);
-    await this.token.setOwnersExplicit(6);
+    await this.token.initializeOwnersExplicit(6);
   });
 
-  it('ownerships correctly set', async function () {
+  it('ownerships correctly initialized', async function () {
     for (let tokenId = 0; tokenId < 6; tokenId++) {
       let owner = await this.token.getOwnershipAt(tokenId);
       expect(owner[0]).to.not.equal(ZERO_ADDRESS);

--- a/test/extensions/ERC721AOwnersExplicit.test.js
+++ b/test/extensions/ERC721AOwnersExplicit.test.js
@@ -16,7 +16,9 @@ const createTestSuite = ({ contract, constructorArgs }) =>
 
       context('with no minted tokens', async function () {
         it('does not have enough tokens minted', async function () {
-          await expect(this.erc721aOwnersExplicit.setOwnersExplicit(1)).to.be.revertedWith('NoTokensMintedYet');
+          await expect(this.erc721aOwnersExplicit.initializeOwnersExplicit(1)).to.be.revertedWith(
+            'NoTokensMintedYet'
+          );
         });
       });
 
@@ -40,70 +42,72 @@ const createTestSuite = ({ contract, constructorArgs }) =>
           await this.erc721aOwnersExplicit['safeMint(address,uint256)'](addr3.address, 3);
         });
 
-        describe('setOwnersExplicit', async function () {
+        describe('initializeOwnersExplicit', async function () {
           it('rejects 0 quantity', async function () {
-            await expect(this.erc721aOwnersExplicit.setOwnersExplicit(0)).to.be.revertedWith('QuantityMustBeNonZero');
+            await expect(this.erc721aOwnersExplicit.initializeOwnersExplicit(0)).to.be.revertedWith(
+              'InitializeZeroQuantity'
+            );
           });
 
           it('handles single increment properly', async function () {
-            await this.erc721aOwnersExplicit.setOwnersExplicit(1);
-            expect(await this.erc721aOwnersExplicit.nextOwnerToExplicitlySet()).to.equal(
+            await this.erc721aOwnersExplicit.initializeOwnersExplicit(1);
+            expect(await this.erc721aOwnersExplicit.nextTokenIdOwnersExplicit()).to.equal(
               (1 + this.startTokenId).toString()
             );
           });
 
-          it('properly sets the ownership of index 2', async function () {
+          it('properly initializes the ownership of index 2', async function () {
             let ownerAtTwo = await this.erc721aOwnersExplicit.getOwnershipAt(2 + this.startTokenId);
             expect(ownerAtTwo[0]).to.equal(ZERO_ADDRESS);
-            await this.erc721aOwnersExplicit.setOwnersExplicit(3);
+            await this.erc721aOwnersExplicit.initializeOwnersExplicit(3);
             ownerAtTwo = await this.erc721aOwnersExplicit.getOwnershipAt(2);
             expect(ownerAtTwo[0]).to.equal(this.addr2.address);
-            expect(await this.erc721aOwnersExplicit.nextOwnerToExplicitlySet()).to.equal(
+            expect(await this.erc721aOwnersExplicit.nextTokenIdOwnersExplicit()).to.equal(
               (3 + this.startTokenId).toString()
             );
           });
 
-          it('sets all ownerships in one go', async function () {
-            await this.erc721aOwnersExplicit.setOwnersExplicit(6);
+          it('initializes all ownerships in one go', async function () {
+            await this.erc721aOwnersExplicit.initializeOwnersExplicit(6);
             for (let tokenId = this.startTokenId; tokenId < 6 + this.startTokenId; tokenId++) {
               let owner = await this.erc721aOwnersExplicit.getOwnershipAt(tokenId);
               expect(owner[0]).to.not.equal(ZERO_ADDRESS);
             }
           });
 
-          it('sets all ownerships with overflowing quantity', async function () {
-            await this.erc721aOwnersExplicit.setOwnersExplicit(15);
+          it('initializes all ownerships with overflowing quantity', async function () {
+            await this.erc721aOwnersExplicit.initializeOwnersExplicit(15);
             for (let tokenId = this.startTokenId; tokenId < 6 + this.startTokenId; tokenId++) {
               let owner = await this.erc721aOwnersExplicit.getOwnershipAt(tokenId);
               expect(owner[0]).to.not.equal(ZERO_ADDRESS);
             }
           });
 
-          it('sets all ownerships in multiple calls', async function () {
-            await this.erc721aOwnersExplicit.setOwnersExplicit(2);
-            expect(await this.erc721aOwnersExplicit.nextOwnerToExplicitlySet()).to.equal(
+          it('initializes all ownerships in multiple calls', async function () {
+            await this.erc721aOwnersExplicit.initializeOwnersExplicit(2);
+            expect(await this.erc721aOwnersExplicit.nextTokenIdOwnersExplicit()).to.equal(
               (2 + this.startTokenId).toString()
             );
-            await this.erc721aOwnersExplicit.setOwnersExplicit(1);
-            expect(await this.erc721aOwnersExplicit.nextOwnerToExplicitlySet()).to.equal(
+            await this.erc721aOwnersExplicit.initializeOwnersExplicit(1);
+            expect(await this.erc721aOwnersExplicit.nextTokenIdOwnersExplicit()).to.equal(
               (3 + this.startTokenId).toString()
             );
-            await this.erc721aOwnersExplicit.setOwnersExplicit(3);
+            await this.erc721aOwnersExplicit.initializeOwnersExplicit(3);
             for (let tokenId = this.startTokenId; tokenId < 6 + this.startTokenId; tokenId++) {
               let owner = await this.erc721aOwnersExplicit.getOwnershipAt(tokenId);
               expect(owner[0]).to.not.equal(ZERO_ADDRESS);
             }
           });
 
-          it('rejects after all ownerships have been set', async function () {
-            await this.erc721aOwnersExplicit.setOwnersExplicit(6);
-            await expect(this.erc721aOwnersExplicit.setOwnersExplicit(1)).to.be.revertedWith(
-              'AllOwnershipsHaveBeenSet'
+          it('rejects after all ownerships have been initialized', async function () {
+            await this.erc721aOwnersExplicit.initializeOwnersExplicit(6);
+            await expect(this.erc721aOwnersExplicit.initializeOwnersExplicit(1)).to.be.revertedWith(
+              'AllOwnershipsInitialized'
             );
           });
 
-          it('sets startTimestamps correctly', async function () {
-            await this.erc721aOwnersExplicit.setOwnersExplicit(6);
+          it('initializes startTimestamps correctly', async function () {
+            await this.erc721aOwnersExplicit.initializeOwnersExplicit(6);
             expect(this.timestampToMine).to.be.eq(this.timestampMined);
             for (let tokenId = this.startTokenId; tokenId < 6 + this.startTokenId; tokenId++) {
               let owner = await this.erc721aOwnersExplicit.getOwnershipAt(tokenId);

--- a/test/extensions/ERC721AQueryable.test.js
+++ b/test/extensions/ERC721AQueryable.test.js
@@ -4,7 +4,7 @@ const { BigNumber } = require('ethers');
 const { constants } = require('@openzeppelin/test-helpers');
 const { ZERO_ADDRESS } = constants;
 
-const createTestSuite = ({ contract, constructorArgs, setOwnersExplicit = false }) =>
+const createTestSuite = ({ contract, constructorArgs, initializeOwnersExplicit = false }) =>
   function () {
     let offseted;
 
@@ -123,10 +123,10 @@ const createTestSuite = ({ contract, constructorArgs, setOwnersExplicit = false 
             expect(await this.erc721aQueryable.balanceOf(minter.address)).to.equal(minter.expected.balance);
           }
 
-          if (setOwnersExplicit) {
+          if (initializeOwnersExplicit) {
             // sanity check
             expect((await this.erc721aQueryable.getOwnershipAt(offseted(4)[0]))[0]).to.equal(ZERO_ADDRESS);
-            await this.erc721aQueryable.setOwnersExplicit(10);
+            await this.erc721aQueryable.initializeOwnersExplicit(10);
             // again, sanity check
             expect((await this.erc721aQueryable.getOwnershipAt(offseted(4)[0]))[0]).to.equal(this.addr3.address);
           }
@@ -311,6 +311,6 @@ describe(
   createTestSuite({
     contract: 'ERC721AQueryableOwnersExplicitMock',
     constructorArgs: ['Azuki', 'AZUKI'],
-    setOwnersExplicit: true,
+    initializeOwnersExplicit: true,
   })
 );


### PR DESCRIPTION
Some changes to make the naming scheme consistent,   
and make certain variables private with internal view getters for read-only access.

### `contracts/ERC721A.sol`

- Variable `_currentIndex` made private.

   Created `_nextTokenId()` internal view function to return the value instead.
    
- Variable `_burnCounter` made private.

   Created `_totalBurned()` internal view function to return the value instead.

These variables are not intended for direct writing by deriving contracts.

The read-only functions are more consistent in naming with existing functions like `_totalMinted()` and `_startTokenId()`. 

This also simplifies accessing the values with Diamond upgradeables   
(users can simply call `_totalBurned()` instead of `ERC721AUpgradable.storage()._burnCounter`).

### `contracts/extensions/ERC721AOwnersExplicit.sol`

- Error `QuantityMustBeNonZero` renamed to `InitializeZeroQuantity`. 

  More consistent naming with other custom errors, such as  `MintZeroQuantity`.

- Error `AllOwnershipsHaveBeenSet` renamed to `AllOwnershipsInitialized`.

- Variable `nextOwnerToExplicitlySet` renamed to `_currentIndexOwnersExplicit` and made private. 

   Created `_nextTokenIdOwnersExplicit()` internal view function to return the value instead.
   
- Function `_setOwnersExplicit` renamed to `_initializeOwnersExplicit`. 

  More consistent naming with function `_initializeOwnershipAt`.

Similarly, the variable is not intended for direct writing by deriving contracts.

Semantically, "initialize" is more appropriate than "set" for their intended use cases,   
as users cannot decide on the values to be written.
