### PR TITLE
Minor transfer optimization

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -630,7 +630,6 @@ contract ERC721A is IERC721A {
         uint256 prevOwnershipPacked = _packedOwnershipOf(tokenId);
 
         address from = address(uint160(prevOwnershipPacked));
-
         address approvedAddress = _tokenApprovals[tokenId];
 
         if (approvalCheck) {


### PR DESCRIPTION
Inspired by https://github.com/Rari-Capital/solmate/pull/252.

It has been under our noses all these while! 

Saves around 60 gas on its own.

Did some extra stuff like assembly casting of address to uint256 and comparing to zero to cut down 36 more gas.

To credit @rotcivegaf upon next release. :)

**Before:**
```
·-------------------------------------------|---------------------------|-------------|-----------------------------·
|           Solc version: 0.8.11            ·  Optimizer enabled: true  ·  Runs: 800  ·  Block limit: 30000000 gas  │
············································|···························|·············|······························
|  Methods                                                                                                          │
···························|················|·············|·············|·············|···············|··············
|  Contract                ·  Method        ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
···························|················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  mintOne       ·      56213  ·      90413  ·      56897  ·           50  ·          -  │
···························|················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  mintTen       ·      73840  ·     108040  ·      75484  ·           52  ·          -  │
···························|················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  safeMintOne   ·      58943  ·      93143  ·      59627  ·           50  ·          -  │
···························|················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  safeMintTen   ·      76548  ·     110748  ·      77232  ·           50  ·          -  │
···························|················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  transferFrom  ·      44488  ·      86187  ·      46573  ·           20  ·          -  │
···························|················|·············|·············|·············|···············|··············
|  Deployments                              ·                                         ·  % of limit   ·             │
············································|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock                   ·          -  ·          -  ·    1033019  ·        3.4 %  ·          -  │
·-------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```


**After:**

```
·-------------------------------------------|---------------------------|-------------|-----------------------------·
|           Solc version: 0.8.11            ·  Optimizer enabled: true  ·  Runs: 800  ·  Block limit: 30000000 gas  │
············································|···························|·············|······························
|  Methods                                                                                                          │
···························|················|·············|·············|·············|···············|··············
|  Contract                ·  Method        ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
···························|················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  mintOne       ·      56195  ·      90395  ·      56879  ·           50  ·          -  │
···························|················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  mintTen       ·      73822  ·     108022  ·      75466  ·           52  ·          -  │
···························|················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  safeMintOne   ·      58925  ·      93125  ·      59609  ·           50  ·          -  │
···························|················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  safeMintTen   ·      76530  ·     110730  ·      77214  ·           50  ·          -  │
···························|················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  transferFrom  ·      44392  ·      86091  ·      46477  ·           20  ·          -  │
···························|················|·············|·············|·············|···············|··············
|  Deployments                              ·                                         ·  % of limit   ·             │
············································|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock                   ·          -  ·          -  ·    1031927  ·        3.4 %  ·          -  │
·-------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```