### PR TITLE
Tests: Branch coverage for `_initializeOwnershipAt`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erc721a",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "erc721a",
-      "version": "3.3.0",
+      "version": "4.0.0",
       "license": "ISC",
       "devDependencies": {
         "@nomiclabs/hardhat-ethers": "^2.0.4",

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -464,6 +464,19 @@ const createTestSuite = ({ contract, constructorArgs }) =>
             const ownership2 = await this.erc721a.getOwnershipAt(lastTokenId);
             expect(ownership2[0]).to.equal(this.addr3.address);
           });
+
+          it("doesn't set ownership if it's already setted", async function () {
+            const lastTokenId = this.addr3.expected.tokens[2];
+            expect(await this.erc721a.ownerOf(lastTokenId)).to.be.equal(this.addr3.address);
+            const tx1 = await this.erc721a.initializeOwnershipAt(lastTokenId);
+            expect(await this.erc721a.ownerOf(lastTokenId)).to.be.equal(this.addr3.address);
+            const tx2 = await this.erc721a.initializeOwnershipAt(lastTokenId);
+
+            // We assume the 2nd initialization doesn't set again due to less gas used.
+            const receipt1 = await tx1.wait();
+            const receipt2 = await tx2.wait();
+            expect(receipt2.gasUsed.toNumber()).to.be.lessThan(receipt1.gasUsed.toNumber());
+          });
         });
       });
 


### PR DESCRIPTION
I just copy-pasted back @cygaar's cool trick from #290.

Branch coverage from 97.5 to 100.

Before:
```
---------------------------------------|----------|----------|----------|----------|----------------|
File                                   |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
---------------------------------------|----------|----------|----------|----------|----------------|
 contracts/                            |      100 |     97.5 |      100 |      100 |                |
  ERC721A.sol                          |      100 |     97.5 |      100 |      100 |                |
  IERC721A.sol                         |      100 |      100 |      100 |      100 |                |
 contracts/extensions/                 |      100 |      100 |      100 |      100 |                |
  ERC721ABurnable.sol                  |      100 |      100 |      100 |      100 |                |
  ERC721AQueryable.sol                 |      100 |      100 |      100 |      100 |                |
  IERC721ABurnable.sol                 |      100 |      100 |      100 |      100 |                |
  IERC721AQueryable.sol                |      100 |      100 |      100 |      100 |                |
 contracts/interfaces/                 |      100 |      100 |      100 |      100 |                |
  IERC721A.sol                         |      100 |      100 |      100 |      100 |                |
  IERC721ABurnable.sol                 |      100 |      100 |      100 |      100 |                |
  IERC721AQueryable.sol                |      100 |      100 |      100 |      100 |                |
 contracts/mocks/                      |      100 |      100 |      100 |      100 |                |
  ERC721ABurnableMock.sol              |      100 |      100 |      100 |      100 |                |
  ERC721ABurnableStartTokenIdMock.sol  |      100 |      100 |      100 |      100 |                |
  ERC721AGasReporterMock.sol           |      100 |      100 |      100 |      100 |                |
  ERC721AMock.sol                      |      100 |      100 |      100 |      100 |                |
  ERC721AQueryableMock.sol             |      100 |      100 |      100 |      100 |                |
  ERC721AQueryableStartTokenIdMock.sol |      100 |      100 |      100 |      100 |                |
  ERC721AStartTokenIdMock.sol          |      100 |      100 |      100 |      100 |                |
  ERC721ReceiverMock.sol               |      100 |      100 |      100 |      100 |                |
  StartTokenIdHelper.sol               |      100 |      100 |      100 |      100 |                |
---------------------------------------|----------|----------|----------|----------|----------------|
All files                              |      100 |       98 |      100 |      100 |                |
---------------------------------------|----------|----------|----------|----------|----------------|
```

After:
```
---------------------------------------|----------|----------|----------|----------|----------------|
File                                   |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
---------------------------------------|----------|----------|----------|----------|----------------|
 contracts/                            |      100 |      100 |      100 |      100 |                |
  ERC721A.sol                          |      100 |      100 |      100 |      100 |                |
  IERC721A.sol                         |      100 |      100 |      100 |      100 |                |
 contracts/extensions/                 |      100 |      100 |      100 |      100 |                |
  ERC721ABurnable.sol                  |      100 |      100 |      100 |      100 |                |
  ERC721AQueryable.sol                 |      100 |      100 |      100 |      100 |                |
  IERC721ABurnable.sol                 |      100 |      100 |      100 |      100 |                |
  IERC721AQueryable.sol                |      100 |      100 |      100 |      100 |                |
 contracts/interfaces/                 |      100 |      100 |      100 |      100 |                |
  IERC721A.sol                         |      100 |      100 |      100 |      100 |                |
  IERC721ABurnable.sol                 |      100 |      100 |      100 |      100 |                |
  IERC721AQueryable.sol                |      100 |      100 |      100 |      100 |                |
 contracts/mocks/                      |      100 |      100 |      100 |      100 |                |
  ERC721ABurnableMock.sol              |      100 |      100 |      100 |      100 |                |
  ERC721ABurnableStartTokenIdMock.sol  |      100 |      100 |      100 |      100 |                |
  ERC721AGasReporterMock.sol           |      100 |      100 |      100 |      100 |                |
  ERC721AMock.sol                      |      100 |      100 |      100 |      100 |                |
  ERC721AQueryableMock.sol             |      100 |      100 |      100 |      100 |                |
  ERC721AQueryableStartTokenIdMock.sol |      100 |      100 |      100 |      100 |                |
  ERC721AStartTokenIdMock.sol          |      100 |      100 |      100 |      100 |                |
  ERC721ReceiverMock.sol               |      100 |      100 |      100 |      100 |                |
  StartTokenIdHelper.sol               |      100 |      100 |      100 |      100 |                |
---------------------------------------|----------|----------|----------|----------|----------------|
All files                              |      100 |      100 |      100 |      100 |                |
---------------------------------------|----------|----------|----------|----------|----------------|
```