### PR TITLE
Update `package-lock.json` in script

### DIFF
--- a/scripts/release/update-version.js
+++ b/scripts/release/update-version.js
@@ -15,6 +15,12 @@ const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 packageJson.version = version;
 fs.writeFileSync('package.json', JSON.stringify(packageJson, null, 2));
 
+// update package-lock.json version
+const packageLockJson = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'));
+packageLockJson.version = version;
+packageLockJson.packages[""].version = version;
+fs.writeFileSync('package-lock.json', JSON.stringify(packageLockJson, null, 2));
+
 const spdxString = '// SPDX-License-Identifier: MIT';
 const versionPrefix = '// ERC721A Contracts v';
 


### PR DESCRIPTION
The current [update-version](https://github.com/chiru-labs/ERC721A/blob/main/scripts/release/update-version.js) script only updates `package.json` and not `package-lock.json`.
This causes `package-lock.json` to be updated after `npm install` for future contributions like #297. 
Hence this PR adds updating `package-lock.json` to the script.