### PR TITLE
Delete unnecessary space character

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -49,7 +49,7 @@ contract ERC721A is IERC721A {
 
     // The bit mask of the `burned` bit in packed ownership.
     uint256 private constant BITMASK_BURNED = 1 << 224;
-    
+
     // The bit position of the `nextInitialized` bit in packed ownership.
     uint256 private constant BITPOS_NEXT_INITIALIZED = 225;
 
@@ -101,7 +101,7 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * @dev Returns the starting token ID. 
+     * @dev Returns the starting token ID.
      * To change the starting token ID, please override this function.
      */
     function _startTokenId() internal view virtual returns (uint256) {
@@ -117,7 +117,7 @@ contract ERC721A is IERC721A {
 
     /**
      * @dev Returns the total number of tokens in existence.
-     * Burned tokens will reduce the count. 
+     * Burned tokens will reduce the count.
      * To get the total number of tokens minted, please see `_totalMinted`.
      */
     function totalSupply() public view override returns (uint256) {
@@ -667,7 +667,7 @@ contract ERC721A is IERC721A {
             _packedOwnerships[tokenId] =
                 _addressToUint256(from) |
                 (block.timestamp << BITPOS_START_TIMESTAMP) |
-                BITMASK_BURNED | 
+                BITMASK_BURNED |
                 BITMASK_NEXT_INITIALIZED;
 
             // If the next slot may not have been initialized (i.e. `nextInitialized == false`) .
@@ -782,9 +782,9 @@ contract ERC721A is IERC721A {
      */
     function _toString(uint256 value) internal pure returns (string memory ptr) {
         assembly {
-            // The maximum value of a uint256 contains 78 digits (1 byte per digit), 
+            // The maximum value of a uint256 contains 78 digits (1 byte per digit),
             // but we allocate 128 bytes to keep the free memory pointer 32-byte word aliged.
-            // We will need 1 32-byte word to store the length, 
+            // We will need 1 32-byte word to store the length,
             // and 3 32-byte words to store a maximum of 78 digits. Total: 32 + 3 * 32 = 128.
             ptr := add(mload(0x40), 128)
             // Update the free memory pointer to allocate.
@@ -797,7 +797,7 @@ contract ERC721A is IERC721A {
             // The following is essentially a do-while loop that also handles the zero case.
             // Costs a bit more than early returning for the zero case,
             // but cheaper in terms of deployment and overall runtime costs.
-            for { 
+            for {
                 // Initialize and perform the first pass without check.
                 let temp := value
                 // Move the pointer 1 byte leftwards to point to an empty character slot.
@@ -805,14 +805,14 @@ contract ERC721A is IERC721A {
                 // Write the character to the pointer. 48 is the ASCII index of '0'.
                 mstore8(ptr, add(48, mod(temp, 10)))
                 temp := div(temp, 10)
-            } temp { 
+            } temp {
                 // Keep dividing `temp` until zero.
                 temp := div(temp, 10)
             } { // Body of the for loop.
                 ptr := sub(ptr, 1)
                 mstore8(ptr, add(48, mod(temp, 10)))
             }
-            
+
             let length := sub(end, ptr)
             // Move the pointer 32 bytes leftwards to make room for the length.
             ptr := sub(ptr, 32)

--- a/test/GasUsage.test.js
+++ b/test/GasUsage.test.js
@@ -47,7 +47,7 @@ describe('ERC721A Gas Usage', function () {
       for (let i = 0; i < 10; ++i) {
         await this.erc721a.connect(this.addr1).transferFrom(this.addr1.address, this.owner.address, 1);
         await this.erc721a.connect(this.owner).transferFrom(this.owner.address, this.addr1.address, 1);
-      }  
+      }
     });
   });
 });


### PR DESCRIPTION
I just deleted space characters.

[Trailing-spaces](https://marketplace.visualstudio.com/items?itemName=shardulm94.trailing-spaces ) extension with vscode would be helpful to catch any unnecessary space characters easily.

![image](https://user-images.githubusercontent.com/102012918/170921754-1f31cf14-1c5e-423b-8f69-220a734fd2f2.png)

