### PR TITLE
Add ERC721ASplitMint extension

### DIFF
--- a/contracts/extensions/ERC721ASplitMint.sol
+++ b/contracts/extensions/ERC721ASplitMint.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+// ERC721A Contracts v4.0.0
+// Creator: @caffeinum
+
+pragma solidity ^0.8.4;
+
+import '../ERC721A.sol';
+
+/**
+ * @title ERC721A Split Mint
+ * @dev Splits mint into batches by _mintBatchSize tokens. 
+ */
+abstract contract ERC721ASplitMint is ERC721A {
+
+    uint256 constant DEFAULT_MINT_BATCH_SIZE = 10;
+
+    /**
+     * @dev Override _mintBatchSize for your custom needs
+     * Using more than 16000 will probably fail: https://github.com/chiru-labs/ERC721A/issues/83#issuecomment-1125686598
+     * Cannot be zero
+     * We require to implement this function in the child contract
+     */
+    function _mintBatchSize() internal pure virtual returns (uint256) {}
+
+    function _splitMint(
+        address to,
+        uint256 quantity
+    ) internal {
+        _splitMint(to, quantity, '');
+    }
+
+    /**
+     * @dev To save gas, splits mint into batches under the hood.
+     * 
+     * Emits a {Transfer} event.
+     */
+    function _splitMint(
+        address to,
+        uint256 quantity,
+        bytes memory _data
+    ) internal {
+        if (quantity == 0) revert MintZeroQuantity();
+
+        // split quantity in batches by 10 tokens and call mint for each batch
+        uint256 batchSize = _mintBatchSize();
+
+        uint lastBatch = quantity / batchSize;
+        uint remainder = quantity % batchSize;
+
+        for (uint i = 0; i < lastBatch; i++) {
+            _safeMint(to, batchSize, _data);
+        }
+
+        if (remainder > 0) {
+            _safeMint(to, remainder, _data);
+        }
+    }
+}

--- a/contracts/mocks/ERC721ASplitMintMock.sol
+++ b/contracts/mocks/ERC721ASplitMintMock.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+// ERC721A Contracts v4.0.0
+// Creators: Chiru Labs
+
+pragma solidity ^0.8.4;
+
+import "../ERC721A.sol";
+import "../extensions/ERC721ASplitMint.sol";
+
+contract ERC721ASplitMintMock is ERC721A, ERC721ASplitMint {
+    constructor(string memory name_, string memory symbol_) ERC721A(name_, symbol_) {}
+
+    function _mintBatchSize() override internal pure returns (uint256) {
+        return DEFAULT_MINT_BATCH_SIZE;
+    }
+
+    function mint(uint256 quantity) public {
+        _splitMint(msg.sender, quantity);
+    }
+
+}

--- a/test/extensions/ERC721ASplitMint.test.js
+++ b/test/extensions/ERC721ASplitMint.test.js
@@ -1,0 +1,64 @@
+const { deployContract, getBlockTimestamp, mineBlockTimestamp, offsettedIndex } = require('../helpers.js');
+const { expect } = require('chai');
+const { constants } = require('@openzeppelin/test-helpers');
+const { ZERO_ADDRESS } = constants;
+
+const EXPECTED_GAS_PER_MINT_TX = 100_000;
+
+const createTestSuite = ({ contract, constructorArgs }) =>
+  function () {
+    let offsetted;
+
+    context(`${contract}`, function () {
+      beforeEach(async function () {
+        const [owner, addr1, addr2, addr3, addr4] = await ethers.getSigners();
+
+        this.owner = owner;
+
+        this.minter = addr1;
+
+        this.ERC721ASplitMint = await deployContract(contract, constructorArgs);
+
+        this.startTokenId = this.ERC721ASplitMint.startTokenId
+          ? (await this.ERC721ASplitMint.startTokenId()).toNumber()
+          : 0;
+
+        offsetted = (...arr) => offsettedIndex(this.startTokenId, arr);
+      });
+
+      it('should mint', async function () {
+        const tokenId = offsetted(0);
+        const tx = await this.ERC721ASplitMint.connect(this.minter).mint(1);
+
+        await expect(tx).to.emit(this.ERC721ASplitMint, 'Transfer').withArgs(ZERO_ADDRESS, this.minter.address, tokenId);
+
+        const receipt = await tx.wait();
+        const gasUsed = receipt.gasUsed.toNumber();
+
+        console.log(`${contract} mint gas used: ${gasUsed} for 1 token`);
+
+        expect(gasUsed).to.be.below(EXPECTED_GAS_PER_MINT_TX);
+      });
+
+      it('should mint 100 tokens with gas spend less than 1_000_000', async function () {
+        const tx = await this.ERC721ASplitMint.connect(this.minter).mint(100);
+
+        // mints tokens 0-99
+        await expect(tx).to.emit(this.ERC721ASplitMint, 'Transfer').withArgs(ZERO_ADDRESS, this.minter.address, offsetted(0));
+        await expect(tx).to.emit(this.ERC721ASplitMint, 'Transfer').withArgs(ZERO_ADDRESS, this.minter.address, offsetted(1));
+        await expect(tx).to.emit(this.ERC721ASplitMint, 'Transfer').withArgs(ZERO_ADDRESS, this.minter.address, offsetted(50));
+        await expect(tx).to.emit(this.ERC721ASplitMint, 'Transfer').withArgs(ZERO_ADDRESS, this.minter.address, offsetted(99));
+
+        const receipt = await tx.wait();
+        const gasUsed = receipt.gasUsed.toNumber();
+
+        console.log(`${contract} mint gas used: ${gasUsed} for 100 tokens`);
+
+        const BATCH_SIZE = 10;
+
+        expect(receipt.gasUsed.toNumber()).to.be.lessThan(BATCH_SIZE * EXPECTED_GAS_PER_MINT_TX);
+      });
+    });
+  };
+
+describe('ERC721ASplitMint', createTestSuite({ contract: 'ERC721ASplitMintMock', constructorArgs: ['Azuki', 'AZUKI'] }));


### PR DESCRIPTION
Automatically split mints into batches to save gas on subsequent transfers

Simplest usage example:
```solidity
import "../ERC721A.sol";
import "../extensions/ERC721ASplitMint.sol";

contract ERC721ASplitMintMock is ERC721A, ERC721ASplitMint {
    constructor(string memory name_, string memory symbol_) ERC721A(name_, symbol_) {}

    function _mintBatchSize() override internal pure returns (uint256) {
        // we require user to override this function so that he explicitly knows the batch size
        return DEFAULT_MINT_BATCH_SIZE;
    }

    function mint(uint256 quantity) public {
       // note we're using _splitMint instead of _safeMint
        _splitMint(msg.sender, quantity);
    }

}

```