### PR TITLE
Remove code duplication in `_safeMint`

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -440,17 +440,19 @@ contract ERC721A is IERC721A {
         bytes memory _data
     ) internal {
         _mint(to, quantity);
-
-        if (to.code.length != 0) {
-            uint256 end = _currentIndex;
-            uint256 index = end - quantity;
-            do {
-                if (!_checkContractOnERC721Received(address(0), to, index++, _data)) {
-                    revert TransferToNonERC721ReceiverImplementer();
-                }
-            } while (index < end);
-            // Reentrancy protection.
-            if (_currentIndex != end) revert();
+        
+        unchecked {
+            if (to.code.length != 0) {
+                uint256 end = _currentIndex;
+                uint256 index = end - quantity;
+                do {
+                    if (!_checkContractOnERC721Received(address(0), to, index++, _data)) {
+                        revert TransferToNonERC721ReceiverImplementer();
+                    }
+                } while (index < end);
+                // Reentrancy protection.
+                if (_currentIndex != end) revert();
+            }
         }
     }
 

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -432,7 +432,7 @@ contract ERC721A is IERC721A {
      *   {IERC721Receiver-onERC721Received}, which is called for each safe transfer.
      * - `quantity` must be greater than 0.
      *
-     * Emits a {Transfer} event.
+     * Emits a {Transfer} event for each mint.
      */
     function _safeMint(
         address to,
@@ -440,7 +440,7 @@ contract ERC721A is IERC721A {
         bytes memory _data
     ) internal {
         _mint(to, quantity);
-        
+
         unchecked {
             if (to.code.length != 0) {
                 uint256 end = _currentIndex;
@@ -464,7 +464,7 @@ contract ERC721A is IERC721A {
      * - `to` cannot be the zero address.
      * - `quantity` must be greater than 0.
      *
-     * Emits a {Transfer} event.
+     * Emits a {Transfer} event for each mint.
      */
     function _mint(address to, uint256 quantity) internal {
         uint256 startTokenId = _currentIndex;

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -195,7 +195,8 @@ contract ERC721A is IERC721A {
     function _setAux(address owner, uint64 aux) internal {
         uint256 packed = _packedAddressData[owner];
         uint256 auxCasted;
-        assembly { // Cast aux without masking.
+        assembly {
+            // Cast aux without masking.
             auxCasted := aux
         }
         packed = (packed & BITMASK_AUX_COMPLEMENT) | (auxCasted << BITPOS_AUX);
@@ -494,14 +495,12 @@ contract ERC721A is IERC721A {
                 (block.timestamp << BITPOS_START_TIMESTAMP) |
                 (_boolToUint256(quantity == 1) << BITPOS_NEXT_INITIALIZED);
 
-            uint256 updatedIndex = startTokenId;
-            uint256 end = updatedIndex + quantity;
-
+            uint256 offset;
             do {
-                emit Transfer(address(0), to, updatedIndex++);
-            } while (updatedIndex < end);
+                emit Transfer(address(0), to, startTokenId + offset++);
+            } while (offset < quantity);
 
-            _currentIndex = updatedIndex;
+            _currentIndex = startTokenId + quantity;
         }
         _afterTokenTransfers(address(0), to, startTokenId, quantity);
     }
@@ -776,7 +775,8 @@ contract ERC721A is IERC721A {
             } temp {
                 // Keep dividing `temp` until zero.
                 temp := div(temp, 10)
-            } { // Body of the for loop.
+            } {
+                // Body of the for loop.
                 ptr := sub(ptr, 1)
                 mstore8(ptr, add(48, mod(temp, 10)))
             }

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -439,53 +439,19 @@ contract ERC721A is IERC721A {
         uint256 quantity,
         bytes memory _data
     ) internal {
-        uint256 startTokenId = _currentIndex;
-        if (_addressToUint256(to) == 0) revert MintToZeroAddress();
-        if (quantity == 0) revert MintZeroQuantity();
+        _mint(to, quantity);
 
-        _beforeTokenTransfers(address(0), to, startTokenId, quantity);
-
-        // Overflows are incredibly unrealistic.
-        // balance or numberMinted overflow if current value of either + quantity > 1.8e19 (2**64) - 1
-        // updatedIndex overflows if _currentIndex + quantity > 1.2e77 (2**256) - 1
-        unchecked {
-            // Updates:
-            // - `balance += quantity`.
-            // - `numberMinted += quantity`.
-            //
-            // We can directly add to the balance and number minted.
-            _packedAddressData[to] += quantity * ((1 << BITPOS_NUMBER_MINTED) | 1);
-
-            // Updates:
-            // - `address` to the owner.
-            // - `startTimestamp` to the timestamp of minting.
-            // - `burned` to `false`.
-            // - `nextInitialized` to `quantity == 1`.
-            _packedOwnerships[startTokenId] =
-                _addressToUint256(to) |
-                (block.timestamp << BITPOS_START_TIMESTAMP) |
-                (_boolToUint256(quantity == 1) << BITPOS_NEXT_INITIALIZED);
-
-            uint256 updatedIndex = startTokenId;
-            uint256 end = updatedIndex + quantity;
-
-            if (to.code.length != 0) {
-                do {
-                    emit Transfer(address(0), to, updatedIndex);
-                    if (!_checkContractOnERC721Received(address(0), to, updatedIndex++, _data)) {
-                        revert TransferToNonERC721ReceiverImplementer();
-                    }
-                } while (updatedIndex < end);
-                // Reentrancy protection
-                if (_currentIndex != startTokenId) revert();
-            } else {
-                do {
-                    emit Transfer(address(0), to, updatedIndex++);
-                } while (updatedIndex < end);
-            }
-            _currentIndex = updatedIndex;
+        if (to.code.length != 0) {
+            uint256 end = _currentIndex;
+            uint256 index = end - quantity;
+            do {
+                if (!_checkContractOnERC721Received(address(0), to, index++, _data)) {
+                    revert TransferToNonERC721ReceiverImplementer();
+                }
+            } while (index < end);
+            // Reentrancy protection.
+            if (_currentIndex != end) revert();
         }
-        _afterTokenTransfers(address(0), to, startTokenId, quantity);
     }
 
     /**


### PR DESCRIPTION
Actually, this saves 2 gas for EOA recipients (which is the most common use case).

It is ok to do the loop twice. Not much overhead (less than 1%).

Strictly speaking, calling `onERC721Received` should also be at the very last part of mint / transfer according to the EIP 
(after all events, state changes, etc).

@cygaar 