### PR TITLE
Refactored gas tests

### DIFF
--- a/contracts/mocks/ERC721AGasReporterMock.sol
+++ b/contracts/mocks/ERC721AGasReporterMock.sol
@@ -24,4 +24,49 @@ contract ERC721AGasReporterMock is ERC721A {
     function mintTen(address to) public {
         _mint(to, 10);
     }
+
+    function transferTenAsc(address to) public {
+        unchecked {
+            transferFrom(msg.sender, to, 0);
+            transferFrom(msg.sender, to, 1);
+            transferFrom(msg.sender, to, 2);
+            transferFrom(msg.sender, to, 3);
+            transferFrom(msg.sender, to, 4);
+            transferFrom(msg.sender, to, 5);
+            transferFrom(msg.sender, to, 6);
+            transferFrom(msg.sender, to, 7);
+            transferFrom(msg.sender, to, 8);
+            transferFrom(msg.sender, to, 9);
+        }
+    }
+
+    function transferTenDesc(address to) public {
+        unchecked {
+            transferFrom(msg.sender, to, 9);
+            transferFrom(msg.sender, to, 8);
+            transferFrom(msg.sender, to, 7);
+            transferFrom(msg.sender, to, 6);
+            transferFrom(msg.sender, to, 5);
+            transferFrom(msg.sender, to, 4);
+            transferFrom(msg.sender, to, 3);
+            transferFrom(msg.sender, to, 2);
+            transferFrom(msg.sender, to, 1);
+            transferFrom(msg.sender, to, 0);
+        }
+    }
+
+    function transferTenAvg(address to) public {
+        unchecked {
+            transferFrom(msg.sender, to, 4);
+            transferFrom(msg.sender, to, 5);
+            transferFrom(msg.sender, to, 3);
+            transferFrom(msg.sender, to, 6);
+            transferFrom(msg.sender, to, 2);
+            transferFrom(msg.sender, to, 7);
+            transferFrom(msg.sender, to, 1);
+            transferFrom(msg.sender, to, 8);
+            transferFrom(msg.sender, to, 0);
+            transferFrom(msg.sender, to, 9);
+        }
+    }
 }

--- a/test/GasUsage.test.js
+++ b/test/GasUsage.test.js
@@ -9,45 +9,63 @@ describe('ERC721A Gas Usage', function () {
   });
 
   context('mintOne', function () {
-    it('runs mintOne 50 times', async function () {
-      for (let i = 0; i < 50; i++) {
+    it('runs mintOne 2 times', async function () {
+      for (let i = 0; i < 2; i++) {
         await this.erc721a.mintOne(this.addr1.address);
       }
     });
   });
 
   context('safeMintOne', function () {
-    it('runs safeMintOne 50 times', async function () {
-      for (let i = 0; i < 50; i++) {
+    it('runs safeMintOne 2 times', async function () {
+      for (let i = 0; i < 2; i++) {
         await this.erc721a.safeMintOne(this.addr1.address);
       }
     });
   });
 
   context('mintTen', function () {
-    it('runs mintTen 50 times', async function () {
-      for (let i = 0; i < 50; i++) {
+    it('runs mintTen 2 times', async function () {
+      for (let i = 0; i < 2; i++) {
         await this.erc721a.mintTen(this.addr1.address);
       }
     });
   });
 
   context('safeMintTen', function () {
-    it('runs safeMintTen 50 times', async function () {
-      for (let i = 0; i < 50; i++) {
+    it('runs safeMintTen 2 times', async function () {
+      for (let i = 0; i < 2; i++) {
         await this.erc721a.safeMintTen(this.addr1.address);
       }
     });
   });
 
   context('transferFrom', function () {
-    it('transfer to and from two addresses', async function () {
-      await this.erc721a.mintTen(this.addr1.address);
+    beforeEach(async function () {
       await this.erc721a.mintTen(this.owner.address);
-      for (let i = 0; i < 10; ++i) {
-        await this.erc721a.connect(this.addr1).transferFrom(this.addr1.address, this.owner.address, 1);
+      await this.erc721a.mintOne(this.owner.address);
+
+      await this.erc721a.mintTen(this.addr1.address);
+      await this.erc721a.mintOne(this.addr1.address);
+    });
+
+    it('transfer to and from two addresses', async function () {
+      for (let i = 0; i < 2; ++i) {
         await this.erc721a.connect(this.owner).transferFrom(this.owner.address, this.addr1.address, 1);
+        await this.erc721a.connect(this.addr1).transferFrom(this.addr1.address, this.owner.address, 1);
       }
+    });
+
+    it('transferTen ascending order', async function () {
+      await this.erc721a.connect(this.owner).transferTenAsc(this.addr1.address);
+    });
+
+    it('transferTen descending order', async function () {
+      await this.erc721a.connect(this.owner).transferTenDesc(this.addr1.address);
+    });
+
+    it('transferTen average order', async function () {
+      await this.erc721a.connect(this.owner).transferTenAvg(this.addr1.address);
     });
   });
 });


### PR DESCRIPTION
- Reduce excess loop iteration. We only need to iterate twice to get the max and min.
- Added some tests for transferring 10 tokens in ascending, descending, and average order.
- Omitted transferring alternating indices, as it only saves less than 1% in gas.
- Inlined `transferFrom` to avoid overhead of iteration, for more accurate results. 
  As such, the "average" case is hardcoded.