### PR TITLE
Remove check for `owner == to` in approve

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -327,7 +327,6 @@ contract ERC721A is IERC721A {
      */
     function approve(address to, uint256 tokenId) public override {
         address owner = address(uint160(_packedOwnershipOf(tokenId)));
-        if (to == owner) revert ApprovalToCurrentOwner();
 
         if (_msgSenderERC721A() != owner)
             if (!isApprovedForAll(owner, _msgSenderERC721A())) {

--- a/contracts/IERC721A.sol
+++ b/contracts/IERC721A.sol
@@ -24,11 +24,6 @@ interface IERC721A {
     error ApproveToCaller();
 
     /**
-     * The caller cannot approve to the current owner.
-     */
-    error ApprovalToCurrentOwner();
-
-    /**
      * Cannot query the balance for the zero address.
      */
     error BalanceQueryForZeroAddress();

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -248,12 +248,6 @@ const createTestSuite = ({ contract, constructorArgs }) =>
             expect(approval).to.equal(this.addr3.address);
           });
 
-          it('rejects an invalid token owner', async function () {
-            await expect(
-              this.erc721a.connect(this.addr1).approve(this.addr2.address, this.tokenId2)
-            ).to.be.revertedWith('ApprovalToCurrentOwner');
-          });
-
           it('rejects an unapproved caller', async function () {
             await expect(this.erc721a.approve(this.addr2.address, this.tokenId)).to.be.revertedWith(
               'ApprovalCallerNotOwnerNorApproved'


### PR DESCRIPTION
https://github.com/OpenZeppelin/openzeppelin-contracts/issues/3346

Solmate does not have the check.