### PR TITLE
Fix typo (change `auxillary` to `auxiliary`)

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -182,14 +182,14 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * Returns the auxillary data for `owner`. (e.g. number of whitelist mint slots used).
+     * Returns the auxiliary data for `owner`. (e.g. number of whitelist mint slots used).
      */
     function _getAux(address owner) internal view returns (uint64) {
         return uint64(_packedAddressData[owner] >> BITPOS_AUX);
     }
 
     /**
-     * Sets the auxillary data for `owner`. (e.g. number of whitelist mint slots used).
+     * Sets the auxiliary data for `owner`. (e.g. number of whitelist mint slots used).
      * If there are multiple variables, please pack them into a uint64.
      */
     function _setAux(address owner, uint64 aux) internal {

--- a/docs/erc721a.md
+++ b/docs/erc721a.md
@@ -304,7 +304,7 @@ Returns the number of tokens burned by or on behalf of `owner`.
 function _getAux(address owner) internal view returns (uint64)
 ```
 
-Returns the auxillary data for `owner` (e.g. number of whitelist mint slots used).
+Returns the auxiliary data for `owner` (e.g. number of whitelist mint slots used).
 
 ### \_setAux
 
@@ -312,7 +312,7 @@ Returns the auxillary data for `owner` (e.g. number of whitelist mint slots used
 function _setAux(address owner, uint64 aux) internal
 ```
 
-Sets the auxillary data for `owner` (e.g. number of whitelist mint slots used).
+Sets the auxiliary data for `owner` (e.g. number of whitelist mint slots used).
 
 If there are multiple variables, please pack them into a `uint64`.
 


### PR DESCRIPTION
Fix small typo in contract and docs.

Change `auxillary` to `auxiliary`.