### PR TITLE
Fix typos in contracts and docs

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -299,7 +299,7 @@ contract ERC721A is IERC721A {
     /**
      * @dev Base URI for computing {tokenURI}. If set, the resulting URI for each
      * token will be the concatenation of the `baseURI` and the `tokenId`. Empty
-     * by default, can be overriden in child contracts.
+     * by default, it can be overridden in child contracts.
      */
     function _baseURI() internal view virtual returns (string memory) {
         return '';

--- a/contracts/mocks/StartTokenIdHelper.sol
+++ b/contracts/mocks/StartTokenIdHelper.sol
@@ -5,9 +5,9 @@
 pragma solidity ^0.8.4;
 
 /**
- * This Helper is used to return a dynmamic value in the overriden _startTokenId() function.
+ * This Helper is used to return a dynamic value in the overridden _startTokenId() function.
  * Extending this Helper before the ERC721A contract give us access to the herein set `startTokenId`
- * to be returned by the overriden `_startTokenId()` function of ERC721A in the ERC721AStartTokenId mocks.
+ * to be returned by the overridden `_startTokenId()` function of ERC721A in the ERC721AStartTokenId mocks.
  */
 contract StartTokenIdHelper {
     uint256 public startTokenId;

--- a/docs/erc721a.md
+++ b/docs/erc721a.md
@@ -433,7 +433,7 @@ Base URI for computing `tokenURI`.
 
 If set, the resulting URI for each token will be the concatenation of the `baseURI` and the `tokenId`.
 
-Empty by default, can be overriden in child contracts.
+Empty by default, it can be overridden in child contracts.
 
 
 ### \_toString


### PR DESCRIPTION
- Change `can be overriden` to `it can be overridden`.
- Change `dynmamic` to `dynamic`.
