### PR TITLE
WIP: Add support for out of order minting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ typechain
 #Hardhat files
 cache
 artifacts
+
+# IDE
+.idea

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -275,10 +275,9 @@ contract ERC721A is IERC721A {
     function _initializeOwnershipAt(uint256 index) internal {
         if (_packedOwnerships[index] == 0) {
             (uint256 packedOwnership, uint256 ownershipIndex) = _packedOwnershipOf(index);
-            uint256 ownershipQuantity = uint256(uint8(packedOwnership >> BITPOS_QUANTITY));
-            uint256 newQuantity =  ownershipIndex + ownershipQuantity - index + 1;
+            uint256 newQuantity = uint256(uint8(packedOwnership >> BITPOS_QUANTITY)) + ownershipIndex - index + 1;
             _packedOwnerships[index] = (packedOwnership & BITMASK_QUANTITY_COMPLEMENT) |
-            (newQuantity << BITPOS_QUANTITY);
+                (newQuantity << BITPOS_QUANTITY);
         }
     }
 
@@ -569,8 +568,8 @@ contract ERC721A is IERC721A {
             // Updates:
             // - `mintCounter` to `mintCounter` + `quantity`
             // - `currentIndex` to `currentIndex` + `quantity` if this is a sequential mint, otherwise `currentIndex`
-            _packedMintCounters = uint128((_packedMintCounters) + quantity) |
-            (((_packedMintCounters >> BITPOS_CURRENT_INDEX) + (_boolToUint256(sequential) * quantity)) << BITPOS_CURRENT_INDEX);
+            _packedMintCounters = uint128((_packedMintCounters) + quantity) | // Update mintCounter
+                (((_packedMintCounters >> BITPOS_CURRENT_INDEX) + (_boolToUint256(sequential) * quantity)) << BITPOS_CURRENT_INDEX); // Conditionally update currentIndex
         }
         _afterTokenTransfers(address(0), to, startTokenId, quantity);
     }
@@ -656,8 +655,8 @@ contract ERC721A is IERC721A {
         // Updates:
         // - `mintCounter` to `mintCounter` + `quantity`
         // - `currentIndex` to `currentIndex` + `quantity` if this is a sequential mint, otherwise `currentIndex`
-        _packedMintCounters = uint128((_packedMintCounters) + quantity) |
-            (((_packedMintCounters >> BITPOS_CURRENT_INDEX) + (_boolToUint256(sequential) * quantity)) << BITPOS_CURRENT_INDEX);
+        _packedMintCounters = uint128((_packedMintCounters) + quantity) | // Update mintCounter
+            (((_packedMintCounters >> BITPOS_CURRENT_INDEX) + (_boolToUint256(sequential) * quantity)) << BITPOS_CURRENT_INDEX); // Conditionally update currentIndex
         }
         _afterTokenTransfers(address(0), to, startTokenId, quantity);
     }

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -284,7 +284,7 @@ contract ERC721A is IERC721A {
     function _initializeOwnershipAt(uint256 index) internal {
         if (_packedOwnerships[index] == 0) {
             (uint256 packedOwnership, uint256 ownershipIndex) = _packedOwnershipOf(index);
-            uint256 newQuantity = uint256(uint8(packedOwnership >> BITPOS_QUANTITY)) + ownershipIndex - index + 1;
+            uint256 newQuantity = uint256(uint8(packedOwnership >> BITPOS_QUANTITY)) + ownershipIndex - index;
             _packedOwnerships[index] = (packedOwnership & BITMASK_QUANTITY_COMPLEMENT) |
                 (newQuantity << BITPOS_QUANTITY);
         }

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -566,13 +566,11 @@ contract ERC721A is IERC721A {
                     emit Transfer(address(0), to, updatedIndex++);
                 } while (updatedIndex < end);
             }
-            uint256 newPackedMintCounters = uint128(_packedMintCounters) + quantity;
-            // If this is a sequential mint, increment _nextTokenId() by quantity.
-            if (sequential) {
-                newPackedMintCounters = newPackedMintCounters |
-                    (((_packedMintCounters >> BITPOS_CURRENT_INDEX) + quantity) << BITPOS_CURRENT_INDEX);
-            }
-            _packedMintCounters = newPackedMintCounters;
+            // Updates:
+            // - `mintCounter` to `mintCounter` + `quantity`
+            // - `currentIndex` to `currentIndex` + `quantity` if this is a sequential mint, otherwise `currentIndex`
+            _packedMintCounters = uint128((_packedMintCounters) + quantity) |
+            (((_packedMintCounters >> BITPOS_CURRENT_INDEX) + (_boolToUint256(sequential) * quantity)) << BITPOS_CURRENT_INDEX);
         }
         _afterTokenTransfers(address(0), to, startTokenId, quantity);
     }
@@ -655,13 +653,11 @@ contract ERC721A is IERC721A {
                 emit Transfer(address(0), to, updatedIndex++);
             } while (updatedIndex < end);
 
-            uint256 newPackedMintCounters = uint128(_packedMintCounters) + quantity;
-            // If this is a sequential mint, increment _nextTokenId() by quantity.
-            if (sequential) {
-                newPackedMintCounters = newPackedMintCounters |
-                    (((_packedMintCounters >> BITPOS_CURRENT_INDEX) + quantity) << BITPOS_CURRENT_INDEX);
-            }
-            _packedMintCounters = newPackedMintCounters;
+        // Updates:
+        // - `mintCounter` to `mintCounter` + `quantity`
+        // - `currentIndex` to `currentIndex` + `quantity` if this is a sequential mint, otherwise `currentIndex`
+        _packedMintCounters = uint128((_packedMintCounters) + quantity) |
+            (((_packedMintCounters >> BITPOS_CURRENT_INDEX) + (_boolToUint256(sequential) * quantity)) << BITPOS_CURRENT_INDEX);
         }
         _afterTokenTransfers(address(0), to, startTokenId, quantity);
     }

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -5,7 +5,6 @@
 pragma solidity ^0.8.4;
 
 import './IERC721A.sol';
-import 'hardhat/console.sol';
 
 /**
  * @dev ERC721 token receiver interface.

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -5,7 +5,7 @@
 pragma solidity ^0.8.4;
 
 import './IERC721A.sol';
-import "hardhat/console.sol";
+import 'hardhat/console.sol';
 
 /**
  * @dev ERC721 token receiver interface.
@@ -125,7 +125,7 @@ contract ERC721A is IERC721A {
     }
 
     /**
- * @dev Returns the lowest possible token ID for non-sequential minting.
+     * @dev Returns the lowest possible token ID for non-sequential minting.
      * To change the lowest possible token ID, please override this function.
      */
     function _minimumTokenId() internal view virtual returns (uint128) {
@@ -140,8 +140,8 @@ contract ERC721A is IERC721A {
     }
 
     /**
-    * @dev Returns the max minting batch size.
-    * To change the max batch size, please override this function.
+     * @dev Returns the max minting batch size.
+     * To change the max batch size, please override this function.
      */
     function _maxBatchSize() internal view virtual returns (uint256) {
         return 10;
@@ -234,7 +234,11 @@ contract ERC721A is IERC721A {
     /**
      * Returns the packed ownership data of `tokenId`.
      */
-    function _packedOwnershipOf(uint256 tokenId) private view returns (uint256 packedOwnership, uint256 ownershipIndex) {
+    function _packedOwnershipOf(uint256 tokenId)
+        private
+        view
+        returns (uint256 packedOwnership, uint256 ownershipIndex)
+    {
         uint256 curr = tokenId;
         if (_minimumTokenId() <= curr) {
             uint256 packed = _packedOwnerships[curr];
@@ -244,7 +248,7 @@ contract ERC721A is IERC721A {
                 if (tokenId >= _maxBatchSize()) {
                     lowestTokenToCheck = tokenId - _maxBatchSize() + 1;
                 }
-                for (; curr >= lowestTokenToCheck && curr >= _minimumTokenId();) {
+                for (; curr >= lowestTokenToCheck && curr >= _minimumTokenId(); ) {
                     // If there exists an ownership record with a quantity that "covers" this token's id,
                     // return that ownership record.  Otherwise, the token doesn't exist so revert.
                     if (packed != 0) {
@@ -285,7 +289,8 @@ contract ERC721A is IERC721A {
         if (_packedOwnerships[index] == 0) {
             (uint256 packedOwnership, uint256 ownershipIndex) = _packedOwnershipOf(index);
             uint256 newQuantity = uint256(uint8(packedOwnership >> BITPOS_QUANTITY)) + ownershipIndex - index;
-            _packedOwnerships[index] = (packedOwnership & BITMASK_QUANTITY_COMPLEMENT) |
+            _packedOwnerships[index] =
+                (packedOwnership & BITMASK_QUANTITY_COMPLEMENT) |
                 (newQuantity << BITPOS_QUANTITY);
         }
     }
@@ -295,7 +300,7 @@ contract ERC721A is IERC721A {
      * It gradually moves to O(1) as tokens get transferred around in the collection over time.
      */
     function _ownershipOf(uint256 tokenId) internal view returns (TokenOwnership memory) {
-        (uint256 packedOwnership,) = _packedOwnershipOf(tokenId);
+        (uint256 packedOwnership, ) = _packedOwnershipOf(tokenId);
         return _unpackedOwnership(packedOwnership);
     }
 
@@ -303,7 +308,7 @@ contract ERC721A is IERC721A {
      * @dev See {IERC721-ownerOf}.
      */
     function ownerOf(uint256 tokenId) public view override returns (address) {
-        (uint256 packedOwnership,) = _packedOwnershipOf(tokenId);
+        (uint256 packedOwnership, ) = _packedOwnershipOf(tokenId);
         return address(uint160(packedOwnership));
     }
 
@@ -362,7 +367,7 @@ contract ERC721A is IERC721A {
      * @dev See {IERC721-approve}.
      */
     function approve(address to, uint256 tokenId) public override {
-        (uint256 packedOwnership,) = _packedOwnershipOf(tokenId);
+        (uint256 packedOwnership, ) = _packedOwnershipOf(tokenId);
         address owner = address(uint160(packedOwnership));
 
         if (_msgSenderERC721A() != owner)
@@ -446,8 +451,7 @@ contract ERC721A is IERC721A {
      * Tokens start existing when they are minted (`_mint`),
      */
     function _exists(uint256 tokenId) internal view returns (bool) {
-        return _isMinted(tokenId) && // If it's minted
-            _packedOwnerships[tokenId] & BITMASK_BURNED == 0; // and not burned.
+        return _isMinted(tokenId) && _packedOwnerships[tokenId] & BITMASK_BURNED == 0; // If it's minted // and not burned.
     }
 
     function _isMinted(uint256 tokenId) internal view returns (bool) {
@@ -473,7 +477,6 @@ contract ERC721A is IERC721A {
     function _safeMint(address to, uint256 quantity) internal {
         _safeMint(to, quantity, '');
     }
-
 
     /**
      * @dev Safely mints `quantity` tokens starting at `_nextTokenId()` and transfers them to `to`.
@@ -583,7 +586,11 @@ contract ERC721A is IERC721A {
      *
      * Emits a {Transfer} event.
      */
-    function _mint(address to, uint256 startTokenId, uint256 quantity) internal {
+    function _mint(
+        address to,
+        uint256 startTokenId,
+        uint256 quantity
+    ) internal {
         _mint(to, startTokenId, quantity, false);
     }
 
@@ -598,7 +605,12 @@ contract ERC721A is IERC721A {
      *
      * Emits a {Transfer} event.
      */
-    function _mint(address to, uint256 startTokenId, uint256 quantity, bool sequential) private {
+    function _mint(
+        address to,
+        uint256 startTokenId,
+        uint256 quantity,
+        bool sequential
+    ) private {
         if (_addressToUint256(to) == 0) revert MintToZeroAddress();
         if (quantity == 0) revert MintZeroQuantity();
         if (quantity > _maxBatchSize()) revert MintLargeQuantity();
@@ -633,11 +645,13 @@ contract ERC721A is IERC721A {
                 emit Transfer(address(0), to, startTokenId + offset++);
             } while (offset < quantity);
 
-        // Updates:
-        // - `mintCounter` to `mintCounter` + `quantity`
-        // - `currentIndex` to `currentIndex` + `quantity` if this is a sequential mint, otherwise `currentIndex`
-        _packedMintCounters = uint128((_packedMintCounters) + quantity) | // Update mintCounter
-            (((_packedMintCounters >> BITPOS_CURRENT_INDEX) + (_boolToUint256(sequential) * quantity)) << BITPOS_CURRENT_INDEX); // Conditionally update currentIndex
+            // Updates:
+            // - `mintCounter` to `mintCounter` + `quantity`
+            // - `currentIndex` to `currentIndex` + `quantity` if this is a sequential mint, otherwise `currentIndex`
+            _packedMintCounters =
+                uint128((_packedMintCounters) + quantity) | // Update mintCounter
+                (((_packedMintCounters >> BITPOS_CURRENT_INDEX) + (_boolToUint256(sequential) * quantity)) <<
+                    BITPOS_CURRENT_INDEX); // Conditionally update currentIndex
         }
         _afterTokenTransfers(address(0), to, startTokenId, quantity);
     }
@@ -709,7 +723,8 @@ contract ERC721A is IERC721A {
                     if ((prevOwnershipIndex + prevOwnershipQuantity - 1) > tokenId) {
                         // Initialize the next slot to maintain correctness for `ownerOf(tokenId + 1)`.
                         // The next slot's quantity should now be `prevOwnershipIndex` + `prevOwnershipQuantity` - 1 - `tokenId`
-                        _packedOwnerships[nextTokenId] = (prevOwnershipPacked & BITMASK_QUANTITY_COMPLEMENT) |
+                        _packedOwnerships[nextTokenId] =
+                            (prevOwnershipPacked & BITMASK_QUANTITY_COMPLEMENT) |
                             ((prevOwnershipIndex + prevOwnershipQuantity - 1 - tokenId) << BITPOS_QUANTITY);
                     }
                 }
@@ -782,7 +797,7 @@ contract ERC721A is IERC721A {
             _packedOwnerships[tokenId] =
                 _addressToUint256(from) |
                 (block.timestamp << BITPOS_START_TIMESTAMP) |
-                BITMASK_BURNED | 
+                BITMASK_BURNED |
                 BITMASK_NEXT_INITIALIZED |
                 (1 << BITPOS_QUANTITY);
 
@@ -795,8 +810,10 @@ contract ERC721A is IERC721A {
                     if ((prevOwnershipIndex + prevOwnershipQuantity - 1) > tokenId) {
                         // Initialize the next slot to maintain correctness for `ownerOf(tokenId + 1)`.
                         // The next slot's quantity should now be `prevOwnershipIndex` + `prevOwnershipQuantity` - 1 - `tokenId`
-                        _packedOwnerships[nextTokenId] = (prevOwnershipPacked & BITMASK_QUANTITY_COMPLEMENT) |
-                            (uint256(uint8(prevOwnershipIndex + prevOwnershipQuantity - 1 - tokenId)) << BITPOS_QUANTITY);
+                        _packedOwnerships[nextTokenId] =
+                            (prevOwnershipPacked & BITMASK_QUANTITY_COMPLEMENT) |
+                            (uint256(uint8(prevOwnershipIndex + prevOwnershipQuantity - 1 - tokenId)) <<
+                                BITPOS_QUANTITY);
                     }
                 }
             }

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -468,7 +468,24 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * @dev Equivalent to `_safeMint(to, _nextTokenId(), quantity, data, true)`.
+     * @dev Equivalent to `_safeMint(to, _nextTokenId(), quantity, '')`.
+     */
+    function _safeMint(address to, uint256 quantity) internal {
+        _safeMint(to, quantity, '');
+    }
+
+
+    /**
+     * @dev Safely mints `quantity` tokens starting at `_nextTokenId()` and transfers them to `to`.
+     *
+     * Requirements:
+     *
+     * - If `to` refers to a smart contract, it must implement
+     *   {IERC721Receiver-onERC721Received}, which is called for each safe transfer.
+     * - `quantity` must be greater than 0.
+     * - `quantity` must be less than or equal to `_maxBatchSize()`.
+     *
+     * Emits a {Transfer} event for each mint.
      */
     function _safeMint(
         address to,
@@ -479,10 +496,14 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * @dev Equivalent to `_safeMint(to, _nextTokenId(), quantity, '')`.
+     * @dev Equivalent to `_safeMint(to, startTokenId, quantity, '')`.
      */
-    function _safeMint(address to, uint256 quantity) internal {
-        _safeMint(to, quantity, '');
+    function _safeMint(
+        address to,
+        uint256 startTokenId,
+        uint256 quantity
+    ) internal {
+        _safeMint(to, startTokenId, quantity, '');
     }
 
     /**
@@ -545,15 +566,7 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * @dev Mints `quantity` tokens starting at _nextTokenId() and transfers them to `to`.
-     *
-     * Requirements:
-     *
-     * - `to` cannot be the zero address.
-     * - `quantity` must be greater than 0.
-     * - `quantity` must be less than or equal to `_maxBatchSize()`.
-     *
-     * Emits a {Transfer} event for each mint.
+     * @dev Equivalent to `_mint(to, _nextTokenId(), quantity)`.
      */
     function _mint(address to, uint256 quantity) internal {
         _mint(to, (_packedMintCounters >> BITPOS_CURRENT_INDEX), quantity, true);

--- a/contracts/IERC721A.sol
+++ b/contracts/IERC721A.sol
@@ -80,6 +80,8 @@ interface IERC721A {
         uint64 startTimestamp;
         // Whether the token has been burned.
         bool burned;
+        // The maximum amount of tokens above this token (inclusive) that this ownership record applies to.
+        uint8 quantity;
     }
 
     /**

--- a/contracts/IERC721A.sol
+++ b/contracts/IERC721A.sol
@@ -44,6 +44,11 @@ interface IERC721A {
     error MintZeroQuantity();
 
     /**
+    * The quantity of tokens minted must be less than or equal to `_maxBatchSize()`.
+    */
+    error MintLargeQuantity();
+
+    /**
      * The token does not exist.
      */
     error OwnerQueryForNonexistentToken();

--- a/contracts/IERC721A.sol
+++ b/contracts/IERC721A.sol
@@ -39,8 +39,8 @@ interface IERC721A {
     error MintZeroQuantity();
 
     /**
-    * The quantity of tokens minted must be less than or equal to `_maxBatchSize()`.
-    */
+     * The quantity of tokens minted must be less than or equal to `_maxBatchSize()`.
+     */
     error MintLargeQuantity();
 
     /**

--- a/contracts/mocks/ERC721ABurnableStartTokenIdMock.sol
+++ b/contracts/mocks/ERC721ABurnableStartTokenIdMock.sol
@@ -11,10 +11,10 @@ contract ERC721ABurnableStartTokenIdMock is StartTokenIdHelper, ERC721ABurnableM
     constructor(
         string memory name_,
         string memory symbol_,
-        uint256 startTokenId_
+        uint128 startTokenId_
     ) StartTokenIdHelper(startTokenId_) ERC721ABurnableMock(name_, symbol_) {}
 
-    function _startTokenId() internal view override returns (uint256) {
+    function _startTokenId() internal view override returns (uint128) {
         return startTokenId;
     }
 }

--- a/contracts/mocks/ERC721AMock.sol
+++ b/contracts/mocks/ERC721AMock.sol
@@ -53,8 +53,29 @@ contract ERC721AMock is ERC721A {
         _safeMint(to, quantity, _data);
     }
 
+    function safeMint(
+        address to,
+        uint256 startTokenId,
+        uint256 quantity
+    ) public {
+        _safeMint(to, startTokenId, quantity);
+    }
+
+    function safeMint(
+        address to,
+        uint256 startTokenId,
+        uint256 quantity,
+        bytes memory data
+    ) public {
+        _safeMint(to, startTokenId, quantity, data);
+    }
+
     function mint(address to, uint256 quantity) public {
         _mint(to, quantity);
+    }
+
+    function mint(address to, uint256 startTokenId, uint256 quantity) public {
+        _mint(to, startTokenId, quantity);
     }
 
     function burn(uint256 tokenId) public {

--- a/contracts/mocks/ERC721AMock.sol
+++ b/contracts/mocks/ERC721AMock.sol
@@ -74,7 +74,11 @@ contract ERC721AMock is ERC721A {
         _mint(to, quantity);
     }
 
-    function mint(address to, uint256 startTokenId, uint256 quantity) public {
+    function mint(
+        address to,
+        uint256 startTokenId,
+        uint256 quantity
+    ) public {
         _mint(to, startTokenId, quantity);
     }
 

--- a/contracts/mocks/ERC721AQueryableStartTokenIdMock.sol
+++ b/contracts/mocks/ERC721AQueryableStartTokenIdMock.sol
@@ -11,10 +11,10 @@ contract ERC721AQueryableStartTokenIdMock is StartTokenIdHelper, ERC721AQueryabl
     constructor(
         string memory name_,
         string memory symbol_,
-        uint256 startTokenId_
+        uint128 startTokenId_
     ) StartTokenIdHelper(startTokenId_) ERC721AQueryableMock(name_, symbol_) {}
 
-    function _startTokenId() internal view override returns (uint256) {
+    function _startTokenId() internal view override returns (uint128) {
         return startTokenId;
     }
 }

--- a/contracts/mocks/ERC721AStartTokenIdMock.sol
+++ b/contracts/mocks/ERC721AStartTokenIdMock.sol
@@ -11,10 +11,10 @@ contract ERC721AStartTokenIdMock is StartTokenIdHelper, ERC721AMock {
     constructor(
         string memory name_,
         string memory symbol_,
-        uint256 startTokenId_
+        uint128 startTokenId_
     ) StartTokenIdHelper(startTokenId_) ERC721AMock(name_, symbol_) {}
 
-    function _startTokenId() internal view override returns (uint256) {
+    function _startTokenId() internal view override returns (uint128) {
         return startTokenId;
     }
 }

--- a/contracts/mocks/StartTokenIdHelper.sol
+++ b/contracts/mocks/StartTokenIdHelper.sol
@@ -10,9 +10,9 @@ pragma solidity ^0.8.4;
  * to be returned by the overriden `_startTokenId()` function of ERC721A in the ERC721AStartTokenId mocks.
  */
 contract StartTokenIdHelper {
-    uint256 public startTokenId;
+    uint128 public startTokenId;
 
-    constructor(uint256 startTokenId_) {
+    constructor(uint128 startTokenId_) {
         startTokenId = startTokenId_;
     }
 }

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -10,14 +10,17 @@ const GAS_MAGIC_VALUE = 20000;
 const createTestSuite = ({ contract, constructorArgs }) =>
   function () {
     let offsetted;
+    let minimumTokenIdOffsetted;
 
     context(`${contract}`, function () {
       beforeEach(async function () {
         this.erc721a = await deployContract(contract, constructorArgs);
         this.receiver = await deployContract('ERC721ReceiverMock', [RECEIVER_MAGIC_VALUE, this.erc721a.address]);
         this.startTokenId = this.erc721a.startTokenId ? (await this.erc721a.startTokenId()).toNumber() : 0;
+        this.minimumTokenId = this.erc721a.minimumTokenId ? (await this.erc721a.minimumTokenId()).toNumber() : 0;
 
         offsetted = (...arr) => offsettedIndex(this.startTokenId, arr);
+        minimumTokenIdOffsetted = (...arr) => offsettedIndex(this.minimumTokenId, arr);
       });
 
       describe('EIP-165 support', async function () {
@@ -80,7 +83,7 @@ const createTestSuite = ({ contract, constructorArgs }) =>
         });
       });
 
-      context('with minted tokens', async function () {
+      context('with sequentially minted tokens', async function () {
         beforeEach(async function () {
           const [owner, addr1, addr2, addr3, addr4] = await ethers.getSigners();
           this.owner = owner;
@@ -225,7 +228,7 @@ const createTestSuite = ({ contract, constructorArgs }) =>
           });
 
           it('reverts for an invalid token', async function () {
-            await expect(this.erc721a.ownerOf(10)).to.be.revertedWith('OwnerQueryForNonexistentToken');
+            await expect(this.erc721a.ownerOf(offsetted(10))).to.be.revertedWith('OwnerQueryForNonexistentToken');
           });
         });
 
@@ -255,7 +258,8 @@ const createTestSuite = ({ contract, constructorArgs }) =>
           });
 
           it('does not get approved for invalid tokens', async function () {
-            await expect(this.erc721a.getApproved(10)).to.be.revertedWith('ApprovalQueryForNonexistentToken');
+            await expect(this.erc721a.getApproved(offsetted(10)))
+              .to.be.revertedWith('ApprovalQueryForNonexistentToken');
           });
 
           it('approval allows token transfer', async function () {
@@ -440,6 +444,422 @@ const createTestSuite = ({ contract, constructorArgs }) =>
         describe('_burn', async function () {
           beforeEach(function () {
             this.tokenIdToBurn = offsetted(0);
+          });
+
+          it('can burn if approvalCheck is false', async function () {
+            expect(await this.erc721a.exists(this.tokenIdToBurn)).to.be.true;
+            await this.erc721a.connect(this.addr2)['burn(uint256,bool)'](this.tokenIdToBurn, false);
+            expect(await this.erc721a.exists(this.tokenIdToBurn)).to.be.false;
+          });
+
+          it('revert if approvalCheck is true', async function () {
+            await expect(
+              this.erc721a.connect(this.addr2)['burn(uint256,bool)'](this.tokenIdToBurn, true)
+            ).to.be.revertedWith('TransferCallerNotOwnerNorApproved');
+          });
+
+          it('can burn without approvalCheck parameter', async function () {
+            expect(await this.erc721a.exists(this.tokenIdToBurn)).to.be.true;
+            await this.erc721a.connect(this.addr2)['burn(uint256)'](this.tokenIdToBurn);
+            expect(await this.erc721a.exists(this.tokenIdToBurn)).to.be.false;
+          });
+        });
+
+        describe('_initializeOwnershipAt', async function () {
+          it('successfuly sets ownership of empty slot', async function () {
+            const lastTokenId = this.addr3.expected.tokens[2];
+            const ownership1 = await this.erc721a.getOwnershipAt(lastTokenId);
+            expect(ownership1[0]).to.equal(ZERO_ADDRESS);
+            await this.erc721a.initializeOwnershipAt(lastTokenId);
+            const ownership2 = await this.erc721a.getOwnershipAt(lastTokenId);
+            expect(ownership2[0]).to.equal(this.addr3.address);
+            // Check quantity
+            expect(ownership2[3]).to.equal(1)
+          });
+
+          it("doesn't set ownership if it's already setted", async function () {
+            const lastTokenId = this.addr3.expected.tokens[2];
+            expect(await this.erc721a.ownerOf(lastTokenId)).to.be.equal(this.addr3.address);
+            const tx1 = await this.erc721a.initializeOwnershipAt(lastTokenId);
+            expect(await this.erc721a.ownerOf(lastTokenId)).to.be.equal(this.addr3.address);
+            const tx2 = await this.erc721a.initializeOwnershipAt(lastTokenId);
+
+            // We assume the 2nd initialization doesn't set again due to less gas used.
+            const receipt1 = await tx1.wait();
+            const receipt2 = await tx2.wait();
+            expect(receipt2.gasUsed.toNumber()).to.be.lessThan(receipt1.gasUsed.toNumber());
+          });
+        });
+      });
+
+      context('with non-sequentially minted tokens', async function () {
+        beforeEach(async function () {
+          const [owner, addr1, addr2, addr3, addr4] = await ethers.getSigners();
+          this.owner = owner;
+          this.addr1 = addr1;
+          this.addr2 = addr2;
+          this.addr3 = addr3;
+          this.addr4 = addr4;
+          this.expectedMintCount = 6;
+
+          this.addr1.expected = {
+            mintCount: 1,
+            tokens: [minimumTokenIdOffsetted(1)],
+          };
+
+          this.addr2.expected = {
+            mintCount: 2,
+            tokens: minimumTokenIdOffsetted(2, 3),
+          };
+
+          this.addr3.expected = {
+            mintCount: 3,
+            tokens: minimumTokenIdOffsetted(5, 6, 7),
+          };
+
+          await this.erc721a['safeMint(address,uint256,uint256)'](addr1.address, minimumTokenIdOffsetted(1),
+            this.addr1.expected.mintCount);
+          await this.erc721a['safeMint(address,uint256,uint256)'](addr2.address, minimumTokenIdOffsetted(2),
+            this.addr2.expected.mintCount);
+          await this.erc721a['safeMint(address,uint256,uint256)'](addr3.address, minimumTokenIdOffsetted(5),
+            this.addr3.expected.mintCount);
+        });
+
+        describe('tokenURI (ERC721Metadata)', async function () {
+          describe('tokenURI', async function () {
+            it('sends an emtpy uri by default', async function () {
+              expect(await this.erc721a.tokenURI(minimumTokenIdOffsetted(1))).to.eq('');
+            });
+
+            it('reverts when tokenId does not exist', async function () {
+              await expect(this.erc721a.tokenURI(minimumTokenIdOffsetted(0))).to.be.revertedWith(
+                'URIQueryForNonexistentToken'
+              );
+            });
+          });
+        });
+
+        describe('exists', async function () {
+          it('verifies valid tokens', async function () {
+            expect(await this.erc721a.exists(minimumTokenIdOffsetted(1))).to.be.true;
+            expect(await this.erc721a.exists(minimumTokenIdOffsetted(2))).to.be.true;
+            expect(await this.erc721a.exists(minimumTokenIdOffsetted(3))).to.be.true;
+            expect(await this.erc721a.exists(minimumTokenIdOffsetted(5))).to.be.true;
+            expect(await this.erc721a.exists(minimumTokenIdOffsetted(6))).to.be.true;
+            expect(await this.erc721a.exists(minimumTokenIdOffsetted(7))).to.be.true;
+          });
+
+          it('verifies invalid tokens', async function () {
+            expect(await this.erc721a.exists(minimumTokenIdOffsetted(0))).to.be.false;
+            expect(await this.erc721a.exists(minimumTokenIdOffsetted(4))).to.be.false;
+            expect(await this.erc721a.exists(minimumTokenIdOffsetted(8))).to.be.false;
+          });
+        });
+
+        describe('balanceOf', async function () {
+          it('returns the amount for a given address', async function () {
+            expect(await this.erc721a.balanceOf(this.owner.address)).to.equal('0');
+            expect(await this.erc721a.balanceOf(this.addr1.address)).to.equal(this.addr1.expected.mintCount);
+            expect(await this.erc721a.balanceOf(this.addr2.address)).to.equal(this.addr2.expected.mintCount);
+            expect(await this.erc721a.balanceOf(this.addr3.address)).to.equal(this.addr3.expected.mintCount);
+          });
+
+          it('returns correct amount with transferred tokens', async function () {
+            const tokenIdToTransfer = this.addr2.expected.tokens[0];
+            await this.erc721a
+              .connect(this.addr2)
+              .transferFrom(this.addr2.address, this.addr3.address, tokenIdToTransfer);
+            // sanity check
+            expect(await this.erc721a.ownerOf(tokenIdToTransfer)).to.equal(this.addr3.address);
+
+            expect(await this.erc721a.balanceOf(this.addr2.address)).to.equal(this.addr2.expected.mintCount - 1);
+            expect(await this.erc721a.balanceOf(this.addr3.address)).to.equal(this.addr3.expected.mintCount + 1);
+          });
+
+          it('throws an exception for the 0 address', async function () {
+            await expect(this.erc721a.balanceOf(ZERO_ADDRESS)).to.be.revertedWith('BalanceQueryForZeroAddress');
+          });
+        });
+
+        describe('_numberMinted', async function () {
+          it('returns the amount for a given address', async function () {
+            expect(await this.erc721a.numberMinted(this.owner.address)).to.equal('0');
+            expect(await this.erc721a.numberMinted(this.addr1.address)).to.equal(this.addr1.expected.mintCount);
+            expect(await this.erc721a.numberMinted(this.addr2.address)).to.equal(this.addr2.expected.mintCount);
+            expect(await this.erc721a.numberMinted(this.addr3.address)).to.equal(this.addr3.expected.mintCount);
+          });
+
+          it('returns the same amount with transferred token', async function () {
+            const tokenIdToTransfer = this.addr2.expected.tokens[0];
+            await this.erc721a
+              .connect(this.addr2)
+              .transferFrom(this.addr2.address, this.addr3.address, tokenIdToTransfer);
+            // sanity check
+            expect(await this.erc721a.ownerOf(tokenIdToTransfer)).to.equal(this.addr3.address);
+
+            expect(await this.erc721a.numberMinted(this.addr2.address)).to.equal(this.addr2.expected.mintCount);
+            expect(await this.erc721a.numberMinted(this.addr3.address)).to.equal(this.addr3.expected.mintCount);
+          });
+        });
+
+        context('_totalMinted', async function () {
+          it('has correct totalMinted', async function () {
+            const totalMinted = await this.erc721a.totalMinted();
+            expect(totalMinted).to.equal(this.expectedMintCount);
+          });
+        });
+
+        context('_nextTokenId', async function () {
+          it('has correct nextTokenId', async function () {
+            const nextTokenId = await this.erc721a.nextTokenId();
+            // This has not changed since we haven't minted sequential tokens
+            expect(nextTokenId).to.equal(offsetted(0));
+          });
+        });
+
+        describe('aux', async function () {
+          it('get and set works correctly', async function () {
+            const uint64Max = BigNumber.from(2).pow(64).sub(1).toString();
+            expect(await this.erc721a.getAux(this.owner.address)).to.equal('0');
+            await this.erc721a.setAux(this.owner.address, uint64Max);
+            expect(await this.erc721a.getAux(this.owner.address)).to.equal(uint64Max);
+
+            expect(await this.erc721a.getAux(this.addr1.address)).to.equal('0');
+            await this.erc721a.setAux(this.addr1.address, '1');
+            expect(await this.erc721a.getAux(this.addr1.address)).to.equal('1');
+
+            await this.erc721a.setAux(this.addr3.address, '5');
+            expect(await this.erc721a.getAux(this.addr3.address)).to.equal('5');
+
+            expect(await this.erc721a.getAux(this.addr1.address)).to.equal('1');
+          });
+        });
+
+        describe('ownerOf', async function () {
+          it('returns the right owner', async function () {
+            for (const minter of [this.addr1, this.addr2, this.addr3]) {
+              for (const tokenId of minter.expected.tokens) {
+                expect(await this.erc721a.ownerOf(tokenId)).to.equal(minter.address);
+              }
+            }
+          });
+
+          it('reverts for an invalid token', async function () {
+            await expect(this.erc721a.ownerOf(10)).to.be.revertedWith('OwnerQueryForNonexistentToken');
+          });
+        });
+
+        describe('approve', async function () {
+          beforeEach(function () {
+            this.tokenId = this.addr1.expected.tokens[0];
+            this.tokenId2 = this.addr2.expected.tokens[0];
+          });
+
+          it('sets approval for the target address', async function () {
+            await this.erc721a.connect(this.addr1).approve(this.addr2.address, this.tokenId);
+            const approval = await this.erc721a.getApproved(this.tokenId);
+            expect(approval).to.equal(this.addr2.address);
+          });
+
+          it('set approval for the target address on behalf of the owner', async function () {
+            await this.erc721a.connect(this.addr1).setApprovalForAll(this.addr2.address, true);
+            await this.erc721a.connect(this.addr2).approve(this.addr3.address, this.tokenId);
+            const approval = await this.erc721a.getApproved(this.tokenId);
+            expect(approval).to.equal(this.addr3.address);
+          });
+
+          it('rejects an unapproved caller', async function () {
+            await expect(this.erc721a.approve(this.addr2.address, this.tokenId)).to.be.revertedWith(
+              'ApprovalCallerNotOwnerNorApproved'
+            );
+          });
+
+          it('does not get approved for invalid tokens', async function () {
+            await expect(this.erc721a.getApproved(10)).to.be.revertedWith('ApprovalQueryForNonexistentToken');
+          });
+
+          it('approval allows token transfer', async function () {
+            await expect(this.erc721a.connect(this.addr3)
+              .transferFrom(this.addr1.address, this.addr3.address, this.tokenId))
+              .to.be.revertedWith('TransferCallerNotOwnerNorApproved');
+            await this.erc721a.connect(this.addr1).approve(this.addr3.address, this.tokenId);
+            await this.erc721a.connect(this.addr3)
+              .transferFrom(this.addr1.address, this.addr3.address, this.tokenId);
+            await expect(this.erc721a.connect(this.addr1)
+              .transferFrom(this.addr3.address, this.addr1.address, this.tokenId))
+              .to.be.revertedWith('TransferCallerNotOwnerNorApproved');
+          });
+        });
+
+        describe('setApprovalForAll', async function () {
+          it('sets approval for all properly', async function () {
+            const approvalTx = await this.erc721a.setApprovalForAll(this.addr1.address, true);
+            await expect(approvalTx)
+              .to.emit(this.erc721a, 'ApprovalForAll')
+              .withArgs(this.owner.address, this.addr1.address, true);
+            expect(await this.erc721a.isApprovedForAll(this.owner.address, this.addr1.address)).to.be.true;
+          });
+
+          it('sets rejects approvals for non msg senders', async function () {
+            await expect(
+              this.erc721a.connect(this.addr1).setApprovalForAll(this.addr1.address, true)
+            ).to.be.revertedWith('ApproveToCaller');
+          });
+        });
+
+        context('test transfer functionality', function () {
+          const testSuccessfulTransfer = function (transferFn, transferToContract = true) {
+            beforeEach(async function () {
+              const sender = this.addr2;
+              this.tokenId = this.addr2.expected.tokens[0];
+              this.from = sender.address;
+              this.to = transferToContract ? this.receiver : this.addr4;
+              await this.erc721a.connect(sender).setApprovalForAll(this.to.address, true);
+
+              const ownershipBefore = await this.erc721a.getOwnershipAt(this.tokenId);
+              this.timestampBefore = parseInt(ownershipBefore.startTimestamp);
+              this.timestampToMine = (await getBlockTimestamp()) + 100;
+              await mineBlockTimestamp(this.timestampToMine);
+              this.timestampMined = await getBlockTimestamp();
+
+              // prettier-ignore
+              this.transferTx = await this.erc721a
+                .connect(sender)[transferFn](this.from, this.to.address, this.tokenId);
+
+              const ownershipAfter = await this.erc721a.getOwnershipAt(this.tokenId);
+              this.timestampAfter = parseInt(ownershipAfter.startTimestamp);
+            });
+
+            it('transfers the ownership of the given token ID to the given address', async function () {
+              expect(await this.erc721a.ownerOf(this.tokenId)).to.be.equal(this.to.address);
+            });
+
+            it('emits a Transfer event', async function () {
+              await expect(this.transferTx)
+                .to.emit(this.erc721a, 'Transfer')
+                .withArgs(this.from, this.to.address, this.tokenId);
+            });
+
+            it('clears the approval for the token ID', async function () {
+              expect(await this.erc721a.getApproved(this.tokenId)).to.be.equal(ZERO_ADDRESS);
+            });
+
+            it('adjusts owners balances', async function () {
+              expect(await this.erc721a.balanceOf(this.from)).to.be.equal(1);
+            });
+
+            it('startTimestamp updated correctly', async function () {
+              expect(this.timestampBefore).to.be.lt(this.timestampToMine);
+              expect(this.timestampAfter).to.be.gte(this.timestampToMine);
+              expect(this.timestampToMine).to.be.eq(this.timestampMined);
+            });
+          };
+
+          const testUnsuccessfulTransfer = function (transferFn) {
+            beforeEach(function () {
+              this.tokenId = this.addr2.expected.tokens[0];
+              this.sender = this.addr1;
+            });
+
+            it('rejects unapproved transfer', async function () {
+              await expect(
+                this.erc721a.connect(this.sender)[transferFn](this.addr2.address, this.sender.address, this.tokenId)
+              ).to.be.revertedWith('TransferCallerNotOwnerNorApproved');
+            });
+
+            it('rejects transfer from incorrect owner', async function () {
+              await this.erc721a.connect(this.addr2).setApprovalForAll(this.sender.address, true);
+              await expect(
+                this.erc721a.connect(this.sender)[transferFn](this.addr3.address, this.sender.address, this.tokenId)
+              ).to.be.revertedWith('TransferFromIncorrectOwner');
+            });
+
+            it('rejects transfer to zero address', async function () {
+              await this.erc721a.connect(this.addr2).setApprovalForAll(this.sender.address, true);
+              await expect(
+                this.erc721a.connect(this.sender)[transferFn](this.addr2.address, ZERO_ADDRESS, this.tokenId)
+              ).to.be.revertedWith('TransferToZeroAddress');
+            });
+          };
+
+          context('successful transfers', function () {
+            context('transferFrom', function () {
+              describe('to contract', function () {
+                testSuccessfulTransfer('transferFrom');
+              });
+
+              describe('to EOA', function () {
+                testSuccessfulTransfer('transferFrom', false);
+              });
+            });
+
+            context('safeTransferFrom', function () {
+              describe('to contract', function () {
+                testSuccessfulTransfer('safeTransferFrom(address,address,uint256)');
+
+                it('validates ERC721Received', async function () {
+                  await expect(this.transferTx)
+                    .to.emit(this.receiver, 'Received')
+                    .withArgs(this.addr2.address, this.addr2.address, this.tokenId, '0x', GAS_MAGIC_VALUE);
+                });
+              });
+
+              describe('to EOA', function () {
+                testSuccessfulTransfer('safeTransferFrom(address,address,uint256)', false);
+              });
+            });
+          });
+
+          context('unsuccessful transfers', function () {
+            describe('transferFrom', function () {
+              testUnsuccessfulTransfer('transferFrom');
+            });
+
+            describe('safeTransferFrom', function () {
+              testUnsuccessfulTransfer('safeTransferFrom(address,address,uint256)');
+
+              it('reverts for non-receivers', async function () {
+                const nonReceiver = this.erc721a;
+                // prettier-ignore
+                await expect(
+                  this.erc721a.connect(this.addr1)['safeTransferFrom(address,address,uint256)'](
+                    this.addr1.address,
+                    nonReceiver.address,
+                    minimumTokenIdOffsetted(1)
+                  )
+                ).to.be.revertedWith('TransferToNonERC721ReceiverImplementer');
+              });
+
+              it('reverts when the receiver reverted', async function () {
+                // prettier-ignore
+                await expect(
+                  this.erc721a.connect(this.addr1)['safeTransferFrom(address,address,uint256,bytes)'](
+                    this.addr1.address,
+                    this.receiver.address,
+                    minimumTokenIdOffsetted(1),
+                    '0x01'
+                  )
+                ).to.be.revertedWith('reverted in the receiver contract!');
+              });
+
+              it('reverts if the receiver returns the wrong value', async function () {
+                // prettier-ignore
+                await expect(
+                  this.erc721a.connect(this.addr1)['safeTransferFrom(address,address,uint256,bytes)'](
+                    this.addr1.address,
+                    this.receiver.address,
+                    minimumTokenIdOffsetted(1),
+                    '0x02'
+                  )
+                ).to.be.revertedWith('TransferToNonERC721ReceiverImplementer');
+              });
+            });
+          });
+        });
+
+        describe('_burn', async function () {
+          beforeEach(function () {
+            this.tokenIdToBurn = minimumTokenIdOffsetted(1);
           });
 
           it('can burn if approvalCheck is false', async function () {
@@ -789,5 +1209,5 @@ describe('ERC721A', createTestSuite({ contract: 'ERC721AMock', constructorArgs: 
 
 describe(
   'ERC721A override _startTokenId()',
-  createTestSuite({ contract: 'ERC721AStartTokenIdMock', constructorArgs: ['Azuki', 'AZUKI', 1] })
+  createTestSuite({ contract: 'ERC721AStartTokenIdMock', constructorArgs: ['Azuki', 'AZUKI', 10] })
 );

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -580,39 +580,15 @@ const createTestSuite = ({ contract, constructorArgs }) =>
 
         const testUnsuccessfulMint = function (safe, sequential = true) {
           beforeEach(async function () {
-            if (safe) {
-              if (sequential) {
-                this.mintFn = 'safeMint(address,uint256)'
-              } else {
-                this.mintFn = 'safeMint(address,uint256,uint256)'
-              }
-            } else {
-              if (sequential) {
-                this.mintFn = 'mint(address,uint256)'
-              } else {
-                this.mintFn = 'mint(address,uint256,uint256)'
-              }
-            }
+            this.mintFn = safe ? 'safeMint(address,uint256)' : 'mint(address,uint256)';
           });
 
           it('rejects mints to the zero address', async function () {
-            if (sequential) {
-              await expect(this.erc721a[this.mintFn](ZERO_ADDRESS, 1))
-                .to.be.revertedWith('MintToZeroAddress');
-            } else {
-              await expect(this.erc721a[this.mintFn](ZERO_ADDRESS, offsetted(1).toNumber(), 1))
-                .to.be.revertedWith('MintToZeroAddress');
-            }
+            await expect(this.erc721a[this.mintFn](ZERO_ADDRESS, 1)).to.be.revertedWith('MintToZeroAddress');
           });
 
-          context('requires quantity to be greater than 0', async function () {
-            if (sequential) {
-              await expect(this.erc721a[this.mintFn](this.owner.address, 0))
-                .to.be.revertedWith('MintZeroQuantity');
-            } else {
-              await expect(this.erc721a[this.mintFn](this.owner.address, offsetted(1).toNumber(),0))
-                .to.be.revertedWith('MintZeroQuantity');
-            }
+          it('requires quantity to be greater than 0', async function () {
+            await expect(this.erc721a[this.mintFn](this.owner.address, 0)).to.be.revertedWith('MintZeroQuantity');
           });
         };
 

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -593,7 +593,6 @@ const createTestSuite = ({ contract, constructorArgs }) =>
                 this.mintFn = 'mint(address,uint256,uint256)'
               }
             }
-            // this.mintFn = safe ? 'safeMint(address,uint256)' : 'mint(address,uint256)';
           });
 
           it('rejects mints to the zero address', async function () {

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -580,15 +580,36 @@ const createTestSuite = ({ contract, constructorArgs }) =>
 
         const testUnsuccessfulMint = function (safe, sequential = true) {
           beforeEach(async function () {
-            this.mintFn = safe ? 'safeMint(address,uint256)' : 'mint(address,uint256)';
+            if (safe) {
+              if (sequential) {
+                this.mintFn = 'safeMint(address,uint256)'
+              } else {
+                this.mintFn = 'safeMint(address,uint256,uint256)'
+              }
+            } else {
+              if (sequential) {
+                this.mintFn = 'mint(address,uint256)'
+              } else {
+                this.mintFn = 'mint(address,uint256,uint256)'
+              }
+            }
+            // this.mintFn = safe ? 'safeMint(address,uint256)' : 'mint(address,uint256)';
           });
 
           it('rejects mints to the zero address', async function () {
-            await expect(this.erc721a[this.mintFn](ZERO_ADDRESS, 1)).to.be.revertedWith('MintToZeroAddress');
+            if (sequential) {
+              await expect(this.erc721a[this.mintFn](ZERO_ADDRESS, 1)).to.be.revertedWith('MintToZeroAddress');
+            } else {
+              await expect(this.erc721a[this.mintFn](ZERO_ADDRESS, 5, 1)).to.be.revertedWith('MintToZeroAddress');
+            }
           });
 
-          it('requires quantity to be greater than 0', async function () {
-            await expect(this.erc721a[this.mintFn](this.owner.address, 0)).to.be.revertedWith('MintZeroQuantity');
+          it.only('requires quantity to be greater than 0', async function () {
+            if (sequential) {
+              await expect(this.erc721a[this.mintFn](this.owner.address, 0)).to.be.revertedWith('MintZeroQuantity');
+            } else {
+              await expect(this.erc721a[this.mintFn](this.owner.address, 5, 0)).to.be.revertedWith('MintZeroQuantity');
+            }
           });
         };
 

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -604,7 +604,7 @@ const createTestSuite = ({ contract, constructorArgs }) =>
             }
           });
 
-          it.only('requires quantity to be greater than 0', async function () {
+          it('requires quantity to be greater than 0', async function () {
             if (sequential) {
               await expect(this.erc721a[this.mintFn](this.owner.address, 0)).to.be.revertedWith('MintZeroQuantity');
             } else {

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -469,6 +469,8 @@ const createTestSuite = ({ contract, constructorArgs }) =>
             await this.erc721a.initializeOwnershipAt(lastTokenId);
             const ownership2 = await this.erc721a.getOwnershipAt(lastTokenId);
             expect(ownership2[0]).to.equal(this.addr3.address);
+            // Check quantity
+            expect(ownership2[3]).to.equal(1)
           });
 
           it("doesn't set ownership if it's already setted", async function () {
@@ -530,12 +532,14 @@ const createTestSuite = ({ contract, constructorArgs }) =>
             const ownership = await this.erc721a.getOwnershipAt(offsetted(0));
             expect(ownership.startTimestamp).to.be.gte(this.timestampToMine);
             expect(ownership.burned).to.be.false;
+            expect(ownership.quantity).to.equal(quantity)
 
             for (let tokenId = offsetted(0); tokenId < offsetted(quantity); tokenId++) {
               const ownership = await this.erc721a.getOwnershipOf(tokenId);
               expect(ownership.addr).to.equal(this.minter.address);
               expect(ownership.startTimestamp).to.be.gte(this.timestampToMine);
               expect(ownership.burned).to.be.false;
+              expect(ownership.quantity).to.equal(quantity)
             }
 
             expect(this.timestampToMine).to.be.eq(this.timestampMined);


### PR DESCRIPTION
Hi!  Wanted to get all of your thoughts on whether some version of these changes/ideas make sense to merge into ERC721A before writing more tests.  Open to any and all feedback!

# Summary
This PR adds new functions to allow batch minting of tokens out of order, while keeping existing sequential batch minting functions.  The extra bookkeeping required to support non-sequential minting adds about 300-400 total gas to sequential minting functions (mintOne and mintTen add roughly the same total gas).  Gas impact on other functions is minimal (I think it's actually less for every other function in unit tests).

# Motivation
The sequential minting of ERC721A works great for most projects, since most mints just need to mint tokens from M to N in order.  For certain drops though (especially secondary drops), out of order batch minting is required to achieve the maximum possible gas savings.  Some examples:
- Chain Runners XR - this is a 20k 3D collection, where we wanted each holder of our 10k genesis collection to receive the corresponding 3D version with the same tokenId (e.g. holder of token ID 1 in the genesis collection could claim token ID 1 in the XR collection).  In addition, we had a public mint of tokens 10,001-20,000 before opening up claims for tokens 1-10k.  An early version of this PR is included in that contract (https://etherscan.io/address/0x4e1824ca2e3dcef21d8eabcf11ccd2b5fd46774b#code#F5#L1).
- Otherdeeds/Otherside - To start, contributors could claim tokens starting at id 30k.  Next, the public sale continued after the last contributor claim token ID.  Finally, BAYC and MAYC holders could claim token IDs 0-29,999.

Since low token IDs are valued more highly by some, it may not be too uncommon for other secondary drops to follow a similar pattern, granting low token IDs to existing holders and offering higher token ids in a public sale.  In addition, if hyped projects like Otherdeeds are not able to take advantage of the gas savings of ERC721A (due to out of order token ID minting requirements), they'll resort to non-optimized ERC721 implementations that end up clogging Ethereum and costing users non-trivial amounts of gas money.

# How?
The main idea behind these changes is to track one additional value (`quantity`) in the `_packedOwnerships` struct on mint, and update it on transfers and burns.  In addition, we enforce a `maxBatchSize` since we can no longer rely on the invariant of having an explicit ownership record below an existing token id. 

As an example, say we want to mint a batch of 3 tokens to address A starting at index 1.  Additionally, we configure `maxBatchSize=5`.  The (simplified) packed ownership records will now look like this:
```
0
1 - quantity=3, address A
2
3
4
```

Here's how existence/owner checks work for each token:
```
0 - No packed ownership within `tokenId - maxBatchSize` and `>= minimumTokenId`.  Does not exist.
1 - Packed ownership record with quantity=3.  1+3-1=3, which is >= this token id (1).  Exists and owned by A.
2 - Packed ownership at token 1 with quantity=3.  1+3-1=3, which is >= this token id (2).  Exists and owned by A.
3 - Packed ownership at token 1 with quantity=3.  1+3-1=3, which is >= this token id (3).  Exists and owned by A.
4 - Packed ownership at token 1 with quantity=3 (note that we search for packed ownerships within `tokenId - maxBatchSize` and `>= minimumTokenId`, so still evaluate the ownership at token id 1).  1+3-1=3, which is NOT >= this token id (4).  Does not exist.
```

Now let's say address A wants to transfer token 2 to address B.  The packed ownership records will be updated to look like this:
```
0
1 - quantity=3, address A.  Note that this quantity does not need to be updated!
2 - quantity=1, address B
3 - quantity=1, address A
4
```

Let's look at the updated existence checks for each token:
```
0 - No packed ownership within `tokenId - maxBatchSize` and `>= minimumTokenId`.  Does not exist.
1 - Packed ownership record with quantity=3.  1+3-1=3, which is >= this token id (1).  Exists and owned by A.
2 - Packed ownership at token 2 with quantity=1.  2+1-1=2, which is >= this token id (2).  Exists and owned by B.
3 - Packed ownership at token 3 with quantity=1.  3+1-1=3, which is >= this token id (3).  Exists and owned by A.
4 - Packed ownership at token 3 with quantity=1.  3+1-1=3, which is NOT >= this token id (4).  Does not exist.
```

One important observation is that we don't actually need to update token id 1's quantity to maintain existence/ownership correctness (shout out to beans for noticing this 🙏).  During a transfer, we will always explicitly set 1) the transferred token id's packed ownership quantity to 1 (token id 2 in this example), and 2) if not explicitly set, the next token id's packed ownership quantity to `oldOwnershipTokenId+oldOwnershipQuantity-transferredTokenId-1` (1+3-2-1=1 in this example) if that value is > 0.  With these explicit ownership updates, we will never run into a situation where token id 1's packed ownership is being used to determine ownership of a token it no longer should - we'll hit the packed ownership of either token id 2 or 3 before hitting token id 1's.


# Limitations
- In the new minting functions that support a `startTokenId`, there are no checks to ensure a given token id range does not already exist (to save gas).  Both the OpenZeppelin ERC721 and ERC721A implementations provide assurances that a token id doesn't exist before minting - OZ has an explicit check (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol#L281) and ERC721A implicitly enforces this by limiting minting to an increasing range.  This makes these new functions somewhat unsafe.  However, in the 2 examples above (Chain Runners XR and Otherdeeds), the calling contracts track which tokens can be minted separately (based on ownership in other contract(s)), so an existence check isn't necessary.  Even so, this can be dangerous, so it might make sense to rename these functions to something that indicates no existence check is made.
- To minimize gas while supporting both the most common use-case (sequential minting) and non-sequential minting, I've packed 2 variables (`currentIndex` and `mintCounter`) into a single `uint256`.  This means both of those variables are now 128 bits, so the supply is effectively capped at the max 128 bit number (vs the max 256 bit number).  Even at 128 bits, this amount should be more than enough for most use cases.  The ERC721 spec even mentions 128 bits is scalable enough: https://eips.ethereum.org/EIPS/eip-721.

# Alternatives Considered
- Rather than keeping the existing sequential minting functions and adding new non-sequential mint functions, I considered removing the sequential minting functions and requiring implementing contracts to track/supply their own currentIndex.  This is cleaner in some ways, but not as gas efficient as packing both `currentIndex` and `mintCounter` into a single `uint256` - `mintCounter` needs to be tracked regardless, so requiring implementers to track their own `currentIndex` adds another uint256 SSTORE.  Also sequential minting is by far the more common use-case, so I wanted to disrupt that API as little as possible.