### PR TITLE
Small gas optimization for burn/transfers/mint 

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -494,10 +494,11 @@ contract ERC721A is IERC721A {
                 (block.timestamp << BITPOS_START_TIMESTAMP) |
                 (_boolToUint256(quantity == 1) << BITPOS_NEXT_INITIALIZED);
 
-            uint256 offset;
+            uint256 offset = startTokenId;
+            uint256 end = quantity + startTokenId;
             do {
-                emit Transfer(address(0), to, startTokenId + offset++);
-            } while (offset < quantity);
+                emit Transfer(address(0), to, offset++);
+            } while (offset < end);
 
             _currentIndex = startTokenId + quantity;
         }


### PR DESCRIPTION
first commit:
- saves 9 gas per burn
- saves 3 gas per transfer
- increases deployment cost but imo worth it

second commit:
- saves 6*(quantity-1)-8 gas per mint
- imo super worth the additional upfront cost

https://www.diffchecker.com/rYLkEpYd