### PR TITLE
Add function to directly set extra data

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -794,10 +794,7 @@ contract ERC721A is IERC721A {
         address to,
         uint256 prevOwnershipPacked
     ) private view returns (uint256) {
-        uint24 extraData;
-        assembly {
-            extraData := shr(BITPOS_EXTRA_DATA, prevOwnershipPacked)
-        }
+        uint24 extraData = uint24(prevOwnershipPacked >> BITPOS_EXTRA_DATA);
         return uint256(_extraData(from, to, extraData)) << BITPOS_EXTRA_DATA;
     }
 

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -210,10 +210,11 @@ contract ERC721A is IERC721A {
      */
     function _setAux(address owner, uint64 aux) internal {
         uint256 packed = _packedAddressData[owner];
-        // Update the `aux` with minimal operations.
+        // Update `aux` with assembly to avoid redundant masking.
         assembly {
+            // `(packed & BITMASK_AUX_COMPLEMENT) | (aux << BITPOS_AUX)`.
             packed := or(
-                and(packed, BITMASK_AUX_COMPLEMENT),
+                and(packed, BITMASK_AUX_COMPLEMENT), 
                 shl(BITPOS_AUX, aux)
             )
         }
@@ -773,10 +774,11 @@ contract ERC721A is IERC721A {
     function _setExtraDataAt(uint256 index, uint24 extraData) internal {
         uint256 packed = _packedOwnerships[index];
         if (packed == 0) revert OwnershipNotInitializedForExtraData();
-        // Update the `extraData` with minimal operations.
+        // Update `extraData` with assembly to avoid redundant masking.
         assembly {
+            // `(packed & BITMASK_EXTRA_DATA_COMPLEMENT) | (extraData << BITPOS_EXTRA_DATA)`.
             packed := or(
-                and(packed, BITMASK_EXTRA_DATA_COMPLEMENT),
+                and(packed, BITMASK_EXTRA_DATA_COMPLEMENT), 
                 shl(BITPOS_EXTRA_DATA, extraData)
             )
         }

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -64,7 +64,7 @@ contract ERC721A is IERC721A {
 
     // The mask of the lower 160 bits for addresses.
     uint256 private constant BITMASK_ADDRESS = (1 << 160) - 1;
-    
+
     // The maximum `quantity` that can be minted with `_mintERC2309`.
     // This limit is to prevent overflows on the address data entries.
     // For a limit of 5000, a total of 3.689e15 calls to `_mintERC2309`
@@ -215,9 +215,7 @@ contract ERC721A is IERC721A {
         assembly {
             auxCasted := aux
         }
-        _packedAddressData[owner] =
-            (packed & BITMASK_AUX_COMPLEMENT) |
-            (auxCasted << BITPOS_AUX);;
+        _packedAddressData[owner] = (packed & BITMASK_AUX_COMPLEMENT) | (auxCasted << BITPOS_AUX);
     }
 
     /**
@@ -778,8 +776,7 @@ contract ERC721A is IERC721A {
         assembly {
             extraDataCasted := extraData
         }
-        _packedOwnerships[index] = (packed & BITMASK_EXTRA_DATA_COMPLEMENT) |
-            (extraDataCasted << BITPOS_EXTRA_DATA);
+        _packedOwnerships[index] = (packed & BITMASK_EXTRA_DATA_COMPLEMENT) | (extraDataCasted << BITPOS_EXTRA_DATA);
     }
 
     /**

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -774,15 +774,13 @@ contract ERC721A is IERC721A {
     function _setExtraDataAt(uint256 index, uint24 extraData) internal {
         uint256 packed = _packedOwnerships[index];
         if (packed == 0) revert OwnershipNotInitializedForExtraData();
-        // Update `extraData` with assembly to avoid redundant masking.
+        uint256 extraDataCasted;
+        // Cast `extraData` with assembly to avoid redundant masking.
         assembly {
-            // `(packed & BITMASK_EXTRA_DATA_COMPLEMENT) | (extraData << BITPOS_EXTRA_DATA)`.
-            packed := or(
-                and(packed, BITMASK_EXTRA_DATA_COMPLEMENT), 
-                shl(BITPOS_EXTRA_DATA, extraData)
-            )
+            extraDataCasted := extraData
         }
-        _packedOwnerships[index] = packed;
+        _packedOwnerships[index] = (packed & BITMASK_EXTRA_DATA_COMPLEMENT) |
+            (extraDataCasted << BITPOS_EXTRA_DATA);
     }
 
     /**

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -210,15 +210,14 @@ contract ERC721A is IERC721A {
      */
     function _setAux(address owner, uint64 aux) internal {
         uint256 packed = _packedAddressData[owner];
-        // Update `aux` with assembly to avoid redundant masking.
+        uint256 auxCasted;
+        // Cast `aux` with assembly to avoid redundant masking.
         assembly {
-            // `(packed & BITMASK_AUX_COMPLEMENT) | (aux << BITPOS_AUX)`.
-            packed := or(
-                and(packed, BITMASK_AUX_COMPLEMENT), 
-                shl(BITPOS_AUX, aux)
-            )
+            auxCasted := aux
         }
-        _packedAddressData[owner] = packed;
+        _packedAddressData[owner] =
+            (packed & BITMASK_AUX_COMPLEMENT) |
+            (auxCasted << BITPOS_AUX);;
     }
 
     /**

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -215,7 +215,8 @@ contract ERC721A is IERC721A {
         assembly {
             auxCasted := aux
         }
-        _packedAddressData[owner] = (packed & BITMASK_AUX_COMPLEMENT) | (auxCasted << BITPOS_AUX);
+        packed = (packed & BITMASK_AUX_COMPLEMENT) | (auxCasted << BITPOS_AUX);
+        _packedAddressData[owner] = packed;
     }
 
     /**
@@ -776,7 +777,8 @@ contract ERC721A is IERC721A {
         assembly {
             extraDataCasted := extraData
         }
-        _packedOwnerships[index] = (packed & BITMASK_EXTRA_DATA_COMPLEMENT) | (extraDataCasted << BITPOS_EXTRA_DATA);
+        packed = (packed & BITMASK_EXTRA_DATA_COMPLEMENT) | (extraDataCasted << BITPOS_EXTRA_DATA);
+        _packedOwnerships[index] = packed;
     }
 
     /**

--- a/contracts/IERC721A.sol
+++ b/contracts/IERC721A.sol
@@ -73,6 +73,11 @@ interface IERC721A {
      */
     error MintERC2309QuantityExceedsLimit();
 
+    /**
+     * The `extraData` cannot be set on an unintialized ownership slot.
+     */
+    error OwnershipNotInitializedForExtraData();
+
     struct TokenOwnership {
         // The address of the owner.
         address addr;

--- a/contracts/mocks/ERC721ATransferCounterMock.sol
+++ b/contracts/mocks/ERC721ATransferCounterMock.sol
@@ -22,4 +22,8 @@ contract ERC721ATransferCounterMock is ERC721AMock {
         }
         return previousExtraData + 1;
     }
+
+    function setExtraDataAt(uint256 index, uint24 extraData) public {
+        _setExtraDataAt(index, extraData);
+    }
 }

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -724,8 +724,3 @@ describe('ERC721A with ERC2309', async function () {
     await expect(deployContract('ERC721AWithERC2309Mock', args)).to.be.revertedWith('MintZeroQuantity');
   });
 });
-
-describe(
-  'ERC721A override _extraData()',
-  createTestSuite({ contract: 'ERC721ATransferCounterMock', constructorArgs: ['Azuki', 'AZUKI'] })
-);

--- a/test/extensions/ERC721ATransferCounter.test.js
+++ b/test/extensions/ERC721ATransferCounter.test.js
@@ -8,12 +8,6 @@ const createTestSuite = ({ contract, constructorArgs }) =>
     context(`${contract}`, function () {
       beforeEach(async function () {
         this.erc721aCounter = await deployContract(contract, constructorArgs);
-
-        this.startTokenId = this.erc721aCounter.startTokenId
-          ? (await this.erc721aCounter.startTokenId()).toNumber()
-          : 0;
-
-        offsetted = (...arr) => offsettedIndex(this.startTokenId, arr);
       });
 
       context('with minted tokens', async function () {
@@ -24,12 +18,12 @@ const createTestSuite = ({ contract, constructorArgs }) =>
 
           this.addr1.expected = {
             balance: 1,
-            tokens: [offsetted(0)],
+            tokens: [0],
           };
 
           this.owner.expected = {
             balance: 2,
-            tokens: offsetted(1, 2),
+            tokens: [1, 2],
           };
 
           this.mintOrder = [this.addr1, this.owner];
@@ -82,6 +76,25 @@ const createTestSuite = ({ contract, constructorArgs }) =>
               const ownership = await this.erc721aCounter.getOwnershipAt(test.tokenId);
               expect(ownership.extraData).to.equal(test.expectedData);
             }
+          });
+        });
+
+        describe('setExtraData', function () {
+          it('can set and get the extraData directly', async function () {
+            const extraData = 12345;
+            await this.erc721aCounter.setExtraDataAt(0, extraData);
+            const ownership = await this.erc721aCounter.getOwnershipAt(0);
+            expect(ownership.extraData).to.equal(extraData);
+          });
+
+          it('setting the extraData for uninitialized slot reverts', async function () {
+            const extraData = 12345;
+            await expect(this.erc721aCounter.setExtraDataAt(2, extraData))
+              .to.be.revertedWith('OwnershipNotInitializedForExtraData');
+            await this.erc721aCounter.transferFrom(this.owner.address, this.addr1.address, 2);
+            await this.erc721aCounter.setExtraDataAt(2, extraData);
+            const ownership = await this.erc721aCounter.getOwnershipAt(2);
+            expect(ownership.extraData).to.equal(extraData);
           });
         });
       });

--- a/test/extensions/ERC721ATransferCounter.test.js
+++ b/test/extensions/ERC721ATransferCounter.test.js
@@ -1,10 +1,8 @@
-const { deployContract, offsettedIndex } = require('../helpers.js');
+const { deployContract } = require('../helpers.js');
 const { expect } = require('chai');
 
 const createTestSuite = ({ contract, constructorArgs }) =>
   function () {
-    let offsetted;
-
     context(`${contract}`, function () {
       beforeEach(async function () {
         this.erc721aCounter = await deployContract(contract, constructorArgs);


### PR DESCRIPTION
In case people want to use the extra data to store the type of token.

Changes:
- Changed `_setAux` function body to be consistent with the function body of `_setExtraDataAt`.
- Made `_nextExtraData` private. Forgot to make it private previously.
- Remove redundant test code.
- Renamed a local variable `previousExtraData` to `extraData`. 
   Cuz there is another variable called `prevPackedOwnership`, and this triggers OCD.