### PR TITLE
Minor tidy up

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -706,10 +706,11 @@ contract ERC721A is IERC721A {
 
         (uint256 approvedAddressSlot, address approvedAddress) = _getApprovedAddress(tokenId);
 
-        if (approvalCheck)
+        if (approvalCheck) {
+            // The nested ifs save around 20+ gas over a compound boolean condition.
             if (!_isOwnerOrApproved(approvedAddress, from, _msgSenderERC721A()))
-                // The nested ifs save around 20+ gas over a compound boolean condition.
                 if (!isApprovedForAll(from, _msgSenderERC721A())) revert TransferCallerNotOwnerNorApproved();
+        }
 
         _beforeTokenTransfers(from, address(0), tokenId, 1);
 

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -19,10 +19,11 @@ interface ERC721A__IERC721Receiver {
 }
 
 /**
- * @dev Implementation of https://eips.ethereum.org/EIPS/eip-721[ERC721] Non-Fungible Token Standard, including
- * the Metadata extension. Built to optimize for lower gas during batch mints.
+ * @dev Implementation of https://eips.ethereum.org/EIPS/eip-721[ERC721] Non-Fungible Token Standard,
+ * including the Metadata extension. Built to optimize for lower gas during batch mints.
  *
- * Assumes serials are sequentially minted starting at _startTokenId() (defaults to 0, e.g. 0, 1, 2, 3..).
+ * Assumes serials are sequentially minted starting at `_startTokenId()`
+ * (defaults to 0, e.g. 0, 1, 2, 3..).
  *
  * Assumes that an owner cannot have more than 2**64 - 1 (max value of uint64) of supply.
  *
@@ -332,11 +333,13 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * @dev Casts the boolean to uint256 without branching.
+     * @dev Returns the `nextInitialized` flag set if `quantity` equals 1.
      */
-    function _boolToUint256(bool value) private pure returns (uint256 result) {
+    function _nextInitializedFlag(uint256 quantity) private pure returns (uint256 result) {
+        // For branchless setting of the `nextInitialized` flag.
         assembly {
-            result := value
+            // `(quantity == 1) << BITPOS_NEXT_INITIALIZED`.
+            result := shl(BITPOS_NEXT_INITIALIZED, eq(quantity, 1))
         }
     }
 
@@ -499,16 +502,16 @@ contract ERC721A is IERC721A {
             // - `nextInitialized` to `quantity == 1`.
             _packedOwnerships[startTokenId] = _packOwnershipData(
                 to,
-                (_boolToUint256(quantity == 1) << BITPOS_NEXT_INITIALIZED) | _nextExtraData(address(0), to, 0)
+                _nextInitializedFlag(quantity) | _nextExtraData(address(0), to, 0)
             );
 
             uint256 tokenId = startTokenId;
-            uint256 end = quantity + startTokenId;
+            uint256 end = startTokenId + quantity;
             do {
                 emit Transfer(address(0), to, tokenId++);
             } while (tokenId < end);
 
-            _currentIndex = startTokenId + quantity;
+            _currentIndex = end;
         }
         _afterTokenTransfers(address(0), to, startTokenId, quantity);
     }
@@ -558,7 +561,7 @@ contract ERC721A is IERC721A {
             // - `nextInitialized` to `quantity == 1`.
             _packedOwnerships[startTokenId] = _packOwnershipData(
                 to,
-                (_boolToUint256(quantity == 1) << BITPOS_NEXT_INITIALIZED) | _nextExtraData(address(0), to, 0)
+                _nextInitializedFlag(quantity) | _nextExtraData(address(0), to, 0)
             );
 
             emit ConsecutiveTransfer(startTokenId, startTokenId + quantity - 1, address(0), to);
@@ -704,8 +707,8 @@ contract ERC721A is IERC721A {
         (uint256 approvedAddressSlot, address approvedAddress) = _getApprovedAddress(tokenId);
 
         if (approvalCheck)
-            // The nested ifs save around 20+ gas over a compound boolean condition.
             if (!_isOwnerOrApproved(approvedAddress, from, _msgSenderERC721A()))
+                // The nested ifs save around 20+ gas over a compound boolean condition.
                 if (!isApprovedForAll(from, _msgSenderERC721A())) revert TransferCallerNotOwnerNorApproved();
 
         _beforeTokenTransfers(from, address(0), tokenId, 1);
@@ -830,7 +833,8 @@ contract ERC721A is IERC721A {
     ) internal view virtual returns (uint24) {}
 
     /**
-     * @dev Hook that is called before a set of serially-ordered token ids are about to be transferred. This includes minting.
+     * @dev Hook that is called before a set of serially-ordered token ids are about to be transferred.
+     * This includes minting.
      * And also called before burning one token.
      *
      * startTokenId - the first token id to be transferred
@@ -852,8 +856,8 @@ contract ERC721A is IERC721A {
     ) internal virtual {}
 
     /**
-     * @dev Hook that is called after a set of serially-ordered token ids have been transferred. This includes
-     * minting.
+     * @dev Hook that is called after a set of serially-ordered token ids have been transferred.
+     * This includes minting.
      * And also called after one token has been burned.
      *
      * startTokenId - the first token id to be transferred


### PR DESCRIPTION
Changes:
- Lint
- Refactored `_boolToUint256` with the shifting into a `_nextInitializedFlag` function.   
  The line is too long and triggers my OCD,  
  and we can put the duplicated bitwise shifting stuff into the function.
- Break up some long comments into multiple lines.
- Changed `_currentIndex = startTokenId + quantity;` to ` _currentIndex = end;`. Saves 1 gas.

Comments:

After some consideration, I've decided not to use assembly for the mint loop _for now_.   
I know it saves 30 gas per iteration (0.4% savings for a batch of 10), 
but it is hard to make it look pretty with all the magic numbers.   
Anyway, ETH is cheap now. 