### PR TITLE
Add stricter timestamp tests

### DIFF
--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -297,7 +297,7 @@ const createTestSuite = ({ contract, constructorArgs }) =>
 
               const ownershipBefore = await this.erc721a.getOwnershipAt(this.tokenId);
               this.timestampBefore = parseInt(ownershipBefore.startTimestamp);
-              this.timestampToMine = (await getBlockTimestamp()) + 100;
+              this.timestampToMine = (await getBlockTimestamp()) + 12345;
               await mineBlockTimestamp(this.timestampToMine);
               this.timestampMined = await getBlockTimestamp();
 
@@ -330,6 +330,7 @@ const createTestSuite = ({ contract, constructorArgs }) =>
             it('startTimestamp updated correctly', async function () {
               expect(this.timestampBefore).to.be.lt(this.timestampToMine);
               expect(this.timestampAfter).to.be.gte(this.timestampToMine);
+              expect(this.timestampAfter).to.be.lt(this.timestampToMine + 10);
               expect(this.timestampToMine).to.be.eq(this.timestampMined);
             });
           };
@@ -500,7 +501,7 @@ const createTestSuite = ({ contract, constructorArgs }) =>
 
             this.balanceBefore = (await this.erc721a.balanceOf(this.minter.address)).toNumber();
 
-            this.timestampToMine = (await getBlockTimestamp()) + 100;
+            this.timestampToMine = (await getBlockTimestamp()) + 12345;
             await mineBlockTimestamp(this.timestampToMine);
             this.timestampMined = await getBlockTimestamp();
 
@@ -528,12 +529,14 @@ const createTestSuite = ({ contract, constructorArgs }) =>
           it('adjusts OwnershipAt and OwnershipOf', async function () {
             const ownership = await this.erc721a.getOwnershipAt(offsetted(0));
             expect(ownership.startTimestamp).to.be.gte(this.timestampToMine);
+            expect(ownership.startTimestamp).to.be.lt(this.timestampToMine + 10);
             expect(ownership.burned).to.be.false;
 
             for (let tokenId = offsetted(0); tokenId < offsetted(quantity); tokenId++) {
               const ownership = await this.erc721a.getOwnershipOf(tokenId);
               expect(ownership.addr).to.equal(this.minter.address);
               expect(ownership.startTimestamp).to.be.gte(this.timestampToMine);
+              expect(ownership.startTimestamp).to.be.lt(this.timestampToMine + 10);
               expect(ownership.burned).to.be.false;
             }
 

--- a/test/extensions/ERC721ABurnable.test.js
+++ b/test/extensions/ERC721ABurnable.test.js
@@ -132,7 +132,7 @@ const createTestSuite = ({ contract, constructorArgs }) =>
         const tokenIdToBurn = this.burnedTokenId + 1;
         const ownershipBefore = await this.erc721aBurnable.getOwnershipAt(tokenIdToBurn);
         const timestampBefore = parseInt(ownershipBefore.startTimestamp);
-        const timestampToMine = (await getBlockTimestamp()) + 100;
+        const timestampToMine = (await getBlockTimestamp()) + 12345;
         await mineBlockTimestamp(timestampToMine);
         const timestampMined = await getBlockTimestamp();
         await this.erc721aBurnable.connect(this.addr1).burn(tokenIdToBurn);
@@ -140,6 +140,7 @@ const createTestSuite = ({ contract, constructorArgs }) =>
         const timestampAfter = parseInt(ownershipAfter.startTimestamp);
         expect(timestampBefore).to.be.lt(timestampToMine);
         expect(timestampAfter).to.be.gte(timestampToMine);
+        expect(timestampAfter).to.be.lt(timestampToMine + 10);
         expect(timestampToMine).to.be.eq(timestampMined);
       });
 


### PR DESCRIPTION
This is to rectify and prevent the case of the upper 96 bits of an address not being zeroed,  
causing the `startTimestamp` and `extraData` to be corrupted.

If you comment out the mask in `_packOwnershipData`,   
the tests for burn `startTimestamps` and the burn `extraData` will fail.

Note that the incorrect burn `startTimestamps` are strictly greater than the actual `startTimestamps`.