### PR TITLE
Make all public and internal functions virtual

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -128,7 +128,7 @@ contract ERC721A is IERC721A {
     /**
      * @dev Returns the next token ID to be minted.
      */
-    function _nextTokenId() internal view returns (uint256) {
+    function _nextTokenId() internal view virtual returns (uint256) {
         return _currentIndex;
     }
 
@@ -137,7 +137,7 @@ contract ERC721A is IERC721A {
      * Burned tokens will reduce the count.
      * To get the total number of tokens minted, please see `_totalMinted`.
      */
-    function totalSupply() public view override returns (uint256) {
+    function totalSupply() public view virtual override returns (uint256) {
         // Counter underflow is impossible as _burnCounter cannot be incremented
         // more than `_currentIndex - _startTokenId()` times.
         unchecked {
@@ -148,7 +148,7 @@ contract ERC721A is IERC721A {
     /**
      * @dev Returns the total amount of tokens minted in the contract.
      */
-    function _totalMinted() internal view returns (uint256) {
+    function _totalMinted() internal view virtual returns (uint256) {
         // Counter underflow is impossible as _currentIndex does not decrement,
         // and it is initialized to `_startTokenId()`
         unchecked {
@@ -159,7 +159,7 @@ contract ERC721A is IERC721A {
     /**
      * @dev Returns the total number of tokens burned.
      */
-    function _totalBurned() internal view returns (uint256) {
+    function _totalBurned() internal view virtual returns (uint256) {
         return _burnCounter;
     }
 
@@ -179,7 +179,7 @@ contract ERC721A is IERC721A {
     /**
      * @dev See {IERC721-balanceOf}.
      */
-    function balanceOf(address owner) public view override returns (uint256) {
+    function balanceOf(address owner) public view virtual override returns (uint256) {
         if (owner == address(0)) revert BalanceQueryForZeroAddress();
         return _packedAddressData[owner] & BITMASK_ADDRESS_DATA_ENTRY;
     }
@@ -187,21 +187,21 @@ contract ERC721A is IERC721A {
     /**
      * Returns the number of tokens minted by `owner`.
      */
-    function _numberMinted(address owner) internal view returns (uint256) {
+    function _numberMinted(address owner) internal view virtual returns (uint256) {
         return (_packedAddressData[owner] >> BITPOS_NUMBER_MINTED) & BITMASK_ADDRESS_DATA_ENTRY;
     }
 
     /**
      * Returns the number of tokens burned by or on behalf of `owner`.
      */
-    function _numberBurned(address owner) internal view returns (uint256) {
+    function _numberBurned(address owner) internal view virtual returns (uint256) {
         return (_packedAddressData[owner] >> BITPOS_NUMBER_BURNED) & BITMASK_ADDRESS_DATA_ENTRY;
     }
 
     /**
      * Returns the auxiliary data for `owner`. (e.g. number of whitelist mint slots used).
      */
-    function _getAux(address owner) internal view returns (uint64) {
+    function _getAux(address owner) internal view virtual returns (uint64) {
         return uint64(_packedAddressData[owner] >> BITPOS_AUX);
     }
 
@@ -209,7 +209,7 @@ contract ERC721A is IERC721A {
      * Sets the auxiliary data for `owner`. (e.g. number of whitelist mint slots used).
      * If there are multiple variables, please pack them into a uint64.
      */
-    function _setAux(address owner, uint64 aux) internal {
+    function _setAux(address owner, uint64 aux) internal virtual {
         uint256 packed = _packedAddressData[owner];
         uint256 auxCasted;
         // Cast `aux` with assembly to avoid redundant masking.
@@ -262,14 +262,14 @@ contract ERC721A is IERC721A {
     /**
      * Returns the unpacked `TokenOwnership` struct at `index`.
      */
-    function _ownershipAt(uint256 index) internal view returns (TokenOwnership memory) {
+    function _ownershipAt(uint256 index) internal view virtual returns (TokenOwnership memory) {
         return _unpackedOwnership(_packedOwnerships[index]);
     }
 
     /**
      * @dev Initializes the ownership slot minted at `index` for efficiency purposes.
      */
-    function _initializeOwnershipAt(uint256 index) internal {
+    function _initializeOwnershipAt(uint256 index) internal virtual {
         if (_packedOwnerships[index] == 0) {
             _packedOwnerships[index] = _packedOwnershipOf(index);
         }
@@ -279,7 +279,7 @@ contract ERC721A is IERC721A {
      * Gas spent here starts off proportional to the maximum mint batch size.
      * It gradually moves to O(1) as tokens get transferred around in the collection over time.
      */
-    function _ownershipOf(uint256 tokenId) internal view returns (TokenOwnership memory) {
+    function _ownershipOf(uint256 tokenId) internal view virtual returns (TokenOwnership memory) {
         return _unpackedOwnership(_packedOwnershipOf(tokenId));
     }
 
@@ -298,7 +298,7 @@ contract ERC721A is IERC721A {
     /**
      * @dev See {IERC721-ownerOf}.
      */
-    function ownerOf(uint256 tokenId) public view override returns (address) {
+    function ownerOf(uint256 tokenId) public view virtual override returns (address) {
         return address(uint160(_packedOwnershipOf(tokenId)));
     }
 
@@ -349,7 +349,7 @@ contract ERC721A is IERC721A {
     /**
      * @dev See {IERC721-approve}.
      */
-    function approve(address to, uint256 tokenId) public override {
+    function approve(address to, uint256 tokenId) public virtual override {
         address owner = ownerOf(tokenId);
 
         if (_msgSenderERC721A() != owner)
@@ -364,7 +364,7 @@ contract ERC721A is IERC721A {
     /**
      * @dev See {IERC721-getApproved}.
      */
-    function getApproved(uint256 tokenId) public view override returns (address) {
+    function getApproved(uint256 tokenId) public view virtual override returns (address) {
         if (!_exists(tokenId)) revert ApprovalQueryForNonexistentToken();
 
         return _tokenApprovals[tokenId];
@@ -421,7 +421,7 @@ contract ERC721A is IERC721A {
      *
      * Tokens start existing when they are minted (`_mint`),
      */
-    function _exists(uint256 tokenId) internal view returns (bool) {
+    function _exists(uint256 tokenId) internal view virtual returns (bool) {
         return
             _startTokenId() <= tokenId &&
             tokenId < _currentIndex && // If within bounds,
@@ -431,7 +431,7 @@ contract ERC721A is IERC721A {
     /**
      * @dev Equivalent to `_safeMint(to, quantity, '')`.
      */
-    function _safeMint(address to, uint256 quantity) internal {
+    function _safeMint(address to, uint256 quantity) internal virtual {
         _safeMint(to, quantity, '');
     }
 
@@ -452,7 +452,7 @@ contract ERC721A is IERC721A {
         address to,
         uint256 quantity,
         bytes memory _data
-    ) internal {
+    ) internal virtual {
         _mint(to, quantity);
 
         unchecked {
@@ -480,7 +480,7 @@ contract ERC721A is IERC721A {
      *
      * Emits a {Transfer} event for each mint.
      */
-    function _mint(address to, uint256 quantity) internal {
+    function _mint(address to, uint256 quantity) internal virtual {
         uint256 startTokenId = _currentIndex;
         if (to == address(0)) revert MintToZeroAddress();
         if (quantity == 0) revert MintZeroQuantity();
@@ -540,7 +540,7 @@ contract ERC721A is IERC721A {
      *
      * Emits a {ConsecutiveTransfer} event.
      */
-    function _mintERC2309(address to, uint256 quantity) internal {
+    function _mintERC2309(address to, uint256 quantity) internal virtual {
         uint256 startTokenId = _currentIndex;
         if (to == address(0)) revert MintToZeroAddress();
         if (quantity == 0) revert MintZeroQuantity();
@@ -803,7 +803,7 @@ contract ERC721A is IERC721A {
     /**
      * @dev Directly sets the extra data for the ownership data `index`.
      */
-    function _setExtraDataAt(uint256 index, uint24 extraData) internal {
+    function _setExtraDataAt(uint256 index, uint24 extraData) internal virtual {
         uint256 packed = _packedOwnerships[index];
         if (packed == 0) revert OwnershipNotInitializedForExtraData();
         uint256 extraDataCasted;
@@ -906,7 +906,7 @@ contract ERC721A is IERC721A {
     /**
      * @dev Converts a `uint256` to its ASCII `string` decimal representation.
      */
-    function _toString(uint256 value) internal pure returns (string memory ptr) {
+    function _toString(uint256 value) internal pure virtual returns (string memory ptr) {
         assembly {
             // The maximum value of a uint256 contains 78 digits (1 byte per digit),
             // but we allocate 128 bytes to keep the free memory pointer 32-byte word aliged.

--- a/contracts/extensions/ERC721AQueryable.sol
+++ b/contracts/extensions/ERC721AQueryable.sol
@@ -33,7 +33,7 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
      *   - `burned = `false`
      *   - `extraData` = `<Extra data at start of ownership>`
      */
-    function explicitOwnershipOf(uint256 tokenId) public view override returns (TokenOwnership memory) {
+    function explicitOwnershipOf(uint256 tokenId) public view virtual override returns (TokenOwnership memory) {
         TokenOwnership memory ownership;
         if (tokenId < _startTokenId() || tokenId >= _nextTokenId()) {
             return ownership;
@@ -49,7 +49,13 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
      * @dev Returns an array of `TokenOwnership` structs at `tokenIds` in order.
      * See {ERC721AQueryable-explicitOwnershipOf}
      */
-    function explicitOwnershipsOf(uint256[] memory tokenIds) external view override returns (TokenOwnership[] memory) {
+    function explicitOwnershipsOf(uint256[] memory tokenIds)
+        external
+        view
+        virtual
+        override
+        returns (TokenOwnership[] memory)
+    {
         unchecked {
             uint256 tokenIdsLength = tokenIds.length;
             TokenOwnership[] memory ownerships = new TokenOwnership[](tokenIdsLength);
@@ -76,7 +82,7 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
         address owner,
         uint256 start,
         uint256 stop
-    ) external view override returns (uint256[] memory) {
+    ) external view virtual override returns (uint256[] memory) {
         unchecked {
             if (start >= stop) revert InvalidQueryRange();
             uint256 tokenIdsIdx;
@@ -143,7 +149,7 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
      * multiple smaller scans if the collection is large enough to cause
      * an out-of-gas error (10K pfp collections should be fine).
      */
-    function tokensOfOwner(address owner) external view override returns (uint256[] memory) {
+    function tokensOfOwner(address owner) external view virtual override returns (uint256[] memory) {
         unchecked {
             uint256 tokenIdsIdx;
             address currOwnershipAddr;


### PR DESCRIPTION
For #358 

To be honest, part of my OCD is triggered when functions that are dangerous to be overridden are marked virtual.

But a wise comment from a comrade soothed me. 
![Screen Shot 2022-07-08 at 11 43 15 PM](https://user-images.githubusercontent.com/5889274/178026061-c1e6d3f9-c005-4679-a2df-0093ec4216be.png)

https://twitter.com/rage_pit/status/1545423297667555328?s=20&t=o7Ijl8TrbjRSpXshoqIozA

OpenZeppelin and Solmate recently marked their functions as virtual too.
