### PR TITLE
Use calldata for queryable extension

### DIFF
--- a/contracts/extensions/ERC721AQueryable.sol
+++ b/contracts/extensions/ERC721AQueryable.sol
@@ -49,7 +49,12 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
      * @dev Returns an array of `TokenOwnership` structs at `tokenIds` in order.
      * See {ERC721AQueryable-explicitOwnershipOf}
      */
-    function explicitOwnershipsOf(uint256[] memory tokenIds) external view override returns (TokenOwnership[] memory) {
+    function explicitOwnershipsOf(uint256[] calldata tokenIds)
+        external
+        view
+        override
+        returns (TokenOwnership[] memory)
+    {
         unchecked {
             uint256 tokenIdsLength = tokenIds.length;
             TokenOwnership[] memory ownerships = new TokenOwnership[](tokenIdsLength);


### PR DESCRIPTION
Since this function is marked as external we can use `calldata` instead of `memory` to save a bit on gas (if explicitOwnershipsOf is called from another contract).