### PR TITLE
Fix casting to bytes1 in ERC721ReceiverMock for solc v0.8.4

### DIFF
--- a/contracts/mocks/ERC721ReceiverMock.sol
+++ b/contracts/mocks/ERC721ReceiverMock.sol
@@ -34,16 +34,7 @@ contract ERC721ReceiverMock is ERC721A__IERC721Receiver {
         uint256 tokenId,
         bytes memory data
     ) public override returns (bytes4) {
-        uint256 dataValue;
-        // In v0.8.4, we can't directly cast via `bytes1(data)`.
-        // This assembly allows us to do the casting.
-        assembly {
-            // If `data.length > 0`.
-            if mload(data) {
-                // Load the 0th byte of `data`.
-                dataValue := byte(0, mload(add(data, 0x20)))
-            }
-        }
+        uint256 dataValue = data.length == 0 ? 0 : uint256(uint8(data[0]));
         
         // For testing reverts with a message from the receiver contract.
         if (dataValue == 0x01) {

--- a/contracts/mocks/ERC721ReceiverMock.sol
+++ b/contracts/mocks/ERC721ReceiverMock.sol
@@ -40,10 +40,11 @@ contract ERC721ReceiverMock is ERC721A__IERC721Receiver {
         assembly {
             // If `data.length > 0`.
             if mload(data) {
-                // Load the first byte of `data`.
+                // Load the 0th byte of `data`.
                 dataValue := byte(0, mload(add(data, 0x20)))
             }
         }
+        
         // For testing reverts with a message from the receiver contract.
         if (dataValue == 0x01) {
             revert('reverted in the receiver contract!');

--- a/contracts/mocks/ERC721ReceiverMock.sol
+++ b/contracts/mocks/ERC721ReceiverMock.sol
@@ -34,18 +34,28 @@ contract ERC721ReceiverMock is ERC721A__IERC721Receiver {
         uint256 tokenId,
         bytes memory data
     ) public override returns (bytes4) {
-        // for testing reverts with a message from the receiver contract
-        if (bytes1(data) == 0x01) {
+        uint256 dataValue;
+        // In v0.8.4, we can't directly cast via `bytes1(data)`.
+        // This assembly allows us to do the casting.
+        assembly {
+            // If `data.length > 0`.
+            if mload(data) {
+                // Load the first byte of `data`.
+                dataValue := byte(0, mload(add(data, 0x20)))
+            }
+        }
+        // For testing reverts with a message from the receiver contract.
+        if (dataValue == 0x01) {
             revert('reverted in the receiver contract!');
         }
 
-        // for testing with the returned wrong value from the receiver contract
-        if (bytes1(data) == 0x02) {
+        // For testing with the returned wrong value from the receiver contract.
+        if (dataValue == 0x02) {
             return 0x0;
         }
 
-        // for testing the reentrancy protection
-        if (bytes1(data) == 0x03) {
+        // For testing the reentrancy protection.
+        if (dataValue == 0x03) {
             IERC721AMock(_erc721aMock).safeMint(address(this), 1);
         }
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -14,7 +14,7 @@ if (process.env.REPORT_COVERAGE) {
  */
 module.exports = {
   solidity: {
-    version: '0.8.11',
+    version: '0.8.4',
     settings: {
       optimizer: {
         enabled: true,

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -14,7 +14,7 @@ if (process.env.REPORT_COVERAGE) {
  */
 module.exports = {
   solidity: {
-    version: '0.8.4',
+    version: '0.8.11',
     settings: {
       optimizer: {
         enabled: true,


### PR DESCRIPTION
This is to fix the tests not compiling in solc v0.8.4.