### PR TITLE
Tidy up code

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -163,8 +163,8 @@ contract ERC721A is IERC721A {
      * @dev Returns the total amount of tokens minted in the contract.
      */
     function _totalMinted() internal view virtual returns (uint256) {
-        // Counter underflow is impossible as _currentIndex does not decrement,
-        // and it is initialized to `_startTokenId()`
+        // Counter underflow is impossible as `_currentIndex` does not decrement,
+        // and it is initialized to `_startTokenId()`.
         unchecked {
             return _currentIndex - _startTokenId();
         }
@@ -189,7 +189,7 @@ contract ERC721A is IERC721A {
         // The interface IDs are constants representing the first 4 bytes
         // of the XOR of all function selectors in the interface.
         // See: [ERC165](https://eips.ethereum.org/EIPS/eip-165)
-        // e.g. `bytes4(i.functionA.selector ^ i.functionB.selector ^ ...)`
+        // (e.g. `bytes4(i.functionA.selector ^ i.functionB.selector ^ ...)`)
         return
             interfaceId == 0x01ffc9a7 || // ERC165 interface ID for ERC165.
             interfaceId == 0x80ac58cd || // ERC165 interface ID for ERC721.
@@ -260,7 +260,7 @@ contract ERC721A is IERC721A {
                         // Hence, `curr` will not underflow.
                         //
                         // We can directly compare the packed value.
-                        // If the address is zero, packed is zero.
+                        // If the address is zero, packed will be zero.
                         while (packed == 0) {
                             packed = _packedOwnerships[--curr];
                         }
@@ -693,7 +693,7 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * @dev Transfers `tokenId` token from `from` to `to`.
+     * @dev Transfers `tokenId` from `from` to `to`.
      *
      * Requirements:
      *

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -489,27 +489,27 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * @dev Returns whether the `approvedAddress` is equal to `from` or `msgSender`.
+     * @dev Returns whether `msgSender` is equal to `approvedAddress` or `owner`.
      */
-    function _isOwnerOrApproved(
+    function _isSenderApprovedOrOwner(
         address approvedAddress,
-        address from,
+        address owner,
         address msgSender
     ) private pure returns (bool result) {
         assembly {
-            // Mask `from` to the lower 160 bits, in case the upper bits somehow aren't clean.
-            from := and(from, _BITMASK_ADDRESS)
+            // Mask `owner` to the lower 160 bits, in case the upper bits somehow aren't clean.
+            owner := and(owner, _BITMASK_ADDRESS)
             // Mask `msgSender` to the lower 160 bits, in case the upper bits somehow aren't clean.
             msgSender := and(msgSender, _BITMASK_ADDRESS)
-            // `msgSender == from || msgSender == approvedAddress`.
-            result := or(eq(msgSender, from), eq(msgSender, approvedAddress))
+            // `msgSender == owner || msgSender == approvedAddress`.
+            result := or(eq(msgSender, owner), eq(msgSender, approvedAddress))
         }
     }
 
     /**
      * @dev Returns the storage slot and value for the approved address of `tokenId`.
      */
-    function _getApprovedAddress(uint256 tokenId)
+    function _getApprovedSlotAndAddress(uint256 tokenId)
         private
         view
         returns (uint256 approvedAddressSlot, address approvedAddress)
@@ -548,10 +548,10 @@ contract ERC721A is IERC721A {
 
         if (address(uint160(prevOwnershipPacked)) != from) revert TransferFromIncorrectOwner();
 
-        (uint256 approvedAddressSlot, address approvedAddress) = _getApprovedAddress(tokenId);
+        (uint256 approvedAddressSlot, address approvedAddress) = _getApprovedSlotAndAddress(tokenId);
 
         // The nested ifs save around 20+ gas over a compound boolean condition.
-        if (!_isOwnerOrApproved(approvedAddress, from, _msgSenderERC721A()))
+        if (!_isSenderApprovedOrOwner(approvedAddress, from, _msgSenderERC721A()))
             if (!isApprovedForAll(from, _msgSenderERC721A())) revert TransferCallerNotOwnerNorApproved();
 
         if (to == address(0)) revert TransferToZeroAddress();
@@ -914,11 +914,11 @@ contract ERC721A is IERC721A {
 
         address from = address(uint160(prevOwnershipPacked));
 
-        (uint256 approvedAddressSlot, address approvedAddress) = _getApprovedAddress(tokenId);
+        (uint256 approvedAddressSlot, address approvedAddress) = _getApprovedSlotAndAddress(tokenId);
 
         if (approvalCheck) {
             // The nested ifs save around 20+ gas over a compound boolean condition.
-            if (!_isOwnerOrApproved(approvedAddress, from, _msgSenderERC721A()))
+            if (!_isSenderApprovedOrOwner(approvedAddress, from, _msgSenderERC721A()))
                 if (!isApprovedForAll(from, _msgSenderERC721A())) revert TransferCallerNotOwnerNorApproved();
         }
 

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.8.4;
 import './IERC721A.sol';
 
 /**
- * @dev ERC721 token receiver interface.
+ * @dev Interface of ERC721 token receiver.
  */
 interface ERC721A__IERC721Receiver {
     function onERC721Received(
@@ -19,15 +19,19 @@ interface ERC721A__IERC721Receiver {
 }
 
 /**
- * @dev Implementation of https://eips.ethereum.org/EIPS/eip-721[ERC721] Non-Fungible Token Standard,
- * including the Metadata extension. Built to optimize for lower gas during batch mints.
+ * @title ERC721A
  *
- * Assumes serials are sequentially minted starting at `_startTokenId()`
- * (defaults to 0, e.g. 0, 1, 2, 3..).
+ * @dev Implementation of the [ERC721](https://eips.ethereum.org/EIPS/eip-721)
+ * Non-Fungible Token Standard, including the Metadata extension.
+ * Optimized for lower gas during batch mints.
  *
- * Assumes that an owner cannot have more than 2**64 - 1 (max value of uint64) of supply.
+ * Token IDs are minted in sequential order (e.g. 0, 1, 2, 3, ...)
+ * starting from `_startTokenId()`.
  *
- * Assumes that the maximum token id cannot exceed 2**256 - 1 (max value of uint256).
+ * Assumptions:
+ *
+ * - An owner cannot have more than 2**64 - 1 (max value of uint64) of supply.
+ * - The maximum token id cannot exceed 2**256 - 1 (max value of uint256).
  */
 contract ERC721A is IERC721A {
     // Reference type for token approval.
@@ -71,9 +75,9 @@ contract ERC721A is IERC721A {
     // The mask of the lower 160 bits for addresses.
     uint256 private constant _BITMASK_ADDRESS = (1 << 160) - 1;
 
-    // The maximum `quantity` that can be minted with `_mintERC2309`.
+    // The maximum `quantity` that can be minted with {_mintERC2309}.
     // This limit is to prevent overflows on the address data entries.
-    // For a limit of 5000, a total of 3.689e15 calls to `_mintERC2309`
+    // For a limit of 5000, a total of 3.689e15 calls to {_mintERC2309}
     // is required to cause an overflow, which is unrealistic.
     uint256 private constant _MAX_MINT_ERC2309_QUANTITY_LIMIT = 5000;
 
@@ -82,7 +86,7 @@ contract ERC721A is IERC721A {
     bytes32 private constant _TRANSFER_EVENT_SIGNATURE =
         0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef;
 
-    // The tokenId of the next token to be minted.
+    // The next token ID to be minted.
     uint256 private _currentIndex;
 
     // The number of tokens burned.
@@ -96,7 +100,7 @@ contract ERC721A is IERC721A {
 
     // Mapping from token ID to ownership details
     // An empty struct value does not necessarily mean the token is unowned.
-    // See `_packedOwnershipOf` implementation for details.
+    // See {_packedOwnershipOf} implementation for details.
     //
     // Bits Layout:
     // - [0..159]   `addr`
@@ -145,7 +149,7 @@ contract ERC721A is IERC721A {
     /**
      * @dev Returns the total number of tokens in existence.
      * Burned tokens will reduce the count.
-     * To get the total number of tokens minted, please see `_totalMinted`.
+     * To get the total number of tokens minted, please see {_totalMinted}.
      */
     function totalSupply() public view virtual override returns (uint256) {
         // Counter underflow is impossible as _burnCounter cannot be incremented
@@ -174,11 +178,17 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * @dev See {IERC165-supportsInterface}.
+     * @dev Returns true if this contract implements the interface defined by
+     * `interfaceId`. See the corresponding
+     * [EIP section](https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified)
+     * to learn more about how these ids are created.
+     *
+     * This function call must use less than 30000 gas.
      */
     function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
-        // The interface IDs are constants representing the first 4 bytes of the XOR of
-        // all function selectors in the interface. See: https://eips.ethereum.org/EIPS/eip-165
+        // The interface IDs are constants representing the first 4 bytes
+        // of the XOR of all function selectors in the interface.
+        // See: [ERC165](https://eips.ethereum.org/EIPS/eip-165)
         // e.g. `bytes4(i.functionA.selector ^ i.functionB.selector ^ ...)`
         return
             interfaceId == 0x01ffc9a7 || // ERC165 interface ID for ERC165.
@@ -187,7 +197,7 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * @dev See {IERC721-balanceOf}.
+     * @dev Returns the number of tokens in `owner`'s account.
      */
     function balanceOf(address owner) public view virtual override returns (uint256) {
         if (owner == address(0)) revert BalanceQueryForZeroAddress();
@@ -243,9 +253,11 @@ contract ERC721A is IERC721A {
                     // If not burned.
                     if (packed & _BITMASK_BURNED == 0) {
                         // Invariant:
-                        // There will always be an ownership that has an address and is not burned
-                        // before an ownership that does not have an address and is not burned.
-                        // Hence, curr will not underflow.
+                        // There will always be an initialized ownership slot
+                        // (i.e. `ownership.addr != address(0) && ownership.burned == false`)
+                        // before an unintialized ownership slot
+                        // (i.e. `ownership.addr == address(0) && ownership.burned == false`)
+                        // Hence, `curr` will not underflow.
                         //
                         // We can directly compare the packed value.
                         // If the address is zero, packed is zero.
@@ -260,7 +272,7 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * Returns the unpacked `TokenOwnership` struct from `packed`.
+     * @dev Returns the unpacked `TokenOwnership` struct from `packed`.
      */
     function _unpackedOwnership(uint256 packed) private pure returns (TokenOwnership memory ownership) {
         ownership.addr = address(uint160(packed));
@@ -270,7 +282,7 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * Returns the unpacked `TokenOwnership` struct at `index`.
+     * @dev Returns the unpacked `TokenOwnership` struct at `index`.
      */
     function _ownershipAt(uint256 index) internal view virtual returns (TokenOwnership memory) {
         return _unpackedOwnership(_packedOwnerships[index]);
@@ -286,8 +298,8 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * Gas spent here starts off proportional to the maximum mint batch size.
-     * It gradually moves to O(1) as tokens get transferred around in the collection over time.
+     * @dev Gas spent here starts off proportional to the maximum mint batch size.
+     * It gradually moves to O(1) as tokens get transferred around over time.
      */
     function _ownershipOf(uint256 tokenId) internal view virtual returns (TokenOwnership memory) {
         return _unpackedOwnership(_packedOwnershipOf(tokenId));
@@ -306,28 +318,32 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * @dev See {IERC721-ownerOf}.
+     * @dev Returns the owner of the `tokenId` token.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
      */
     function ownerOf(uint256 tokenId) public view virtual override returns (address) {
         return address(uint160(_packedOwnershipOf(tokenId)));
     }
 
     /**
-     * @dev See {IERC721Metadata-name}.
+     * @dev Returns the token collection name.
      */
     function name() public view virtual override returns (string memory) {
         return _name;
     }
 
     /**
-     * @dev See {IERC721Metadata-symbol}.
+     * @dev Returns the token collection symbol.
      */
     function symbol() public view virtual override returns (string memory) {
         return _symbol;
     }
 
     /**
-     * @dev See {IERC721Metadata-tokenURI}.
+     * @dev Returns the Uniform Resource Identifier (URI) for `tokenId` token.
      */
     function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
         if (!_exists(tokenId)) revert URIQueryForNonexistentToken();
@@ -357,7 +373,18 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * @dev See {IERC721-approve}.
+     * @dev Gives permission to `to` to transfer `tokenId` token to another account.
+     * The approval is cleared when the token is transferred.
+     *
+     * Only a single account can be approved at a time, so approving the
+     * zero address clears previous approvals.
+     *
+     * Requirements:
+     *
+     * - The caller must own the token or be an approved operator.
+     * - `tokenId` must exist.
+     *
+     * Emits an {Approval} event.
      */
     function approve(address to, uint256 tokenId) public virtual override {
         address owner = ownerOf(tokenId);
@@ -372,7 +399,11 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * @dev See {IERC721-getApproved}.
+     * @dev Returns the account approved for `tokenId` token.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
      */
     function getApproved(uint256 tokenId) public view virtual override returns (address) {
         if (!_exists(tokenId)) revert ApprovalQueryForNonexistentToken();
@@ -381,7 +412,15 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * @dev See {IERC721-setApprovalForAll}.
+     * @dev Approve or remove `operator` as an operator for the caller.
+     * Operators can call {transferFrom} or {safeTransferFrom}
+     * for any token owned by the caller.
+     *
+     * Requirements:
+     *
+     * - The `operator` cannot be the caller.
+     *
+     * Emits an {ApprovalForAll} event.
      */
     function setApprovalForAll(address operator, bool approved) public virtual override {
         if (operator == _msgSenderERC721A()) revert ApproveToCaller();
@@ -391,14 +430,16 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * @dev See {IERC721-isApprovedForAll}.
+     * @dev Returns if the `operator` is allowed to manage all of the assets of `owner`.
+     *
+     * See {setApprovalForAll}.
      */
     function isApprovedForAll(address owner, address operator) public view virtual override returns (bool) {
         return _operatorApprovals[owner][operator];
     }
 
     /**
-     * @dev See {IERC721-safeTransferFrom}.
+     * @dev Equivalent to `safeTransferFrom(from, to, tokenId, '')`.
      */
     function safeTransferFrom(
         address from,
@@ -409,7 +450,19 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * @dev See {IERC721-safeTransferFrom}.
+     * @dev Safely transfers `tokenId` token from `from` to `to`.
+     *
+     * Requirements:
+     *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must exist and be owned by `from`.
+     * - If the caller is not `from`, it must be approved to move this token
+     *   by either {approve} or {setApprovalForAll}.
+     * - If `to` refers to a smart contract, it must implement
+     *   {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     *
+     * Emits a {Transfer} event.
      */
     function safeTransferFrom(
         address from,
@@ -429,7 +482,7 @@ contract ERC721A is IERC721A {
      *
      * Tokens can be managed by their owner or approved accounts via {approve} or {setApprovalForAll}.
      *
-     * Tokens start existing when they are minted (`_mint`),
+     * Tokens start existing when they are minted. See {_mint}.
      */
     function _exists(uint256 tokenId) internal view virtual returns (bool) {
         return
@@ -640,12 +693,15 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * @dev Transfers `tokenId` from `from` to `to`.
+     * @dev Transfers `tokenId` token from `from` to `to`.
      *
      * Requirements:
      *
+     * - `from` cannot be the zero address.
      * - `to` cannot be the zero address.
      * - `tokenId` token must be owned by `from`.
+     * - If the caller is not `from`, it must be approved to move this token
+     *   by either {approve} or {setApprovalForAll}.
      *
      * Emits a {Transfer} event.
      */
@@ -678,7 +734,7 @@ contract ERC721A is IERC721A {
 
         // Underflow of the sender's balance is impossible because we check for
         // ownership above and the recipient's balance can't realistically overflow.
-        // Counter overflow is incredibly unrealistic as tokenId would have to be 2**256.
+        // Counter overflow is incredibly unrealistic as `tokenId` would have to be 2**256.
         unchecked {
             // We can directly increment and decrement the balances.
             --_packedAddressData[from]; // Updates: `balance -= 1`.
@@ -876,8 +932,8 @@ contract ERC721A is IERC721A {
     ) internal view virtual returns (uint24) {}
 
     /**
-     * @dev Hook that is called before a set of serially-ordered token ids are about to be transferred.
-     * This includes minting.
+     * @dev Hook that is called before a set of serially-ordered token IDs
+     * are about to be transferred. This includes minting.
      * And also called before burning one token.
      *
      * startTokenId - the first token id to be transferred
@@ -899,8 +955,8 @@ contract ERC721A is IERC721A {
     ) internal virtual {}
 
     /**
-     * @dev Hook that is called after a set of serially-ordered token ids have been transferred.
-     * This includes minting.
+     * @dev Hook that is called after a set of serially-ordered token IDs
+     * have been transferred. This includes minting.
      * And also called after one token has been burned.
      *
      * startTokenId - the first token id to be transferred

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -458,9 +458,9 @@ contract ERC721A is IERC721A {
      * - `to` cannot be the zero address.
      * - `tokenId` token must exist and be owned by `from`.
      * - If the caller is not `from`, it must be approved to move this token
-     *   by either {approve} or {setApprovalForAll}.
+     * by either {approve} or {setApprovalForAll}.
      * - If `to` refers to a smart contract, it must implement
-     *   {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     * {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
      *
      * Emits a {Transfer} event.
      */
@@ -504,7 +504,7 @@ contract ERC721A is IERC721A {
      * Requirements:
      *
      * - If `to` refers to a smart contract, it must implement
-     *   {IERC721Receiver-onERC721Received}, which is called for each safe transfer.
+     * {IERC721Receiver-onERC721Received}, which is called for each safe transfer.
      * - `quantity` must be greater than 0.
      *
      * See {_mint}.
@@ -701,7 +701,7 @@ contract ERC721A is IERC721A {
      * - `to` cannot be the zero address.
      * - `tokenId` token must be owned by `from`.
      * - If the caller is not `from`, it must be approved to move this token
-     *   by either {approve} or {setApprovalForAll}.
+     * by either {approve} or {setApprovalForAll}.
      *
      * Emits a {Transfer} event.
      */
@@ -987,7 +987,7 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * @dev Converts a `uint256` to its ASCII `string` decimal representation.
+     * @dev Converts a uint256 to its ASCII string decimal representation.
      */
     function _toString(uint256 value) internal pure virtual returns (string memory ptr) {
         assembly {
@@ -1011,7 +1011,8 @@ contract ERC721A is IERC721A {
                 let temp := value
                 // Move the pointer 1 byte leftwards to point to an empty character slot.
                 ptr := sub(ptr, 1)
-                // Write the character to the pointer. 48 is the ASCII index of '0'.
+                // Write the character to the pointer.
+                // The ASCII index of the '0' character is 48.
                 mstore8(ptr, add(48, mod(temp, 10)))
                 temp := div(temp, 10)
             } temp {

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -144,7 +144,7 @@ contract ERC721A is IERC721A {
     }
 
     // =============================================================
-    //                    TOKEN COUNT OPERATIONS
+    //                   TOKEN COUNTING OPERATIONS
     // =============================================================
 
     /**
@@ -688,7 +688,7 @@ contract ERC721A is IERC721A {
     ) internal virtual {}
 
     /**
-     * @dev Internal function to invoke {IERC721Receiver-onERC721Received} on a target contract.
+     * @dev Private function to invoke {IERC721Receiver-onERC721Received} on a target contract.
      *
      * @param from address representing the previous owner of the given token ID
      * @param to target address that will receive the tokens
@@ -997,19 +997,6 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * @dev Returns the next extra data for the packed ownership data.
-     * The returned result is shifted into position.
-     */
-    function _nextExtraData(
-        address from,
-        address to,
-        uint256 prevOwnershipPacked
-    ) private view returns (uint256) {
-        uint24 extraData = uint24(prevOwnershipPacked >> _BITPOS_EXTRA_DATA);
-        return uint256(_extraData(from, to, extraData)) << _BITPOS_EXTRA_DATA;
-    }
-
-    /**
      * @dev Called during each token transfer to set the 24bit `extraData` field.
      * Intended to be overridden by the cosumer contract.
      *
@@ -1028,6 +1015,19 @@ contract ERC721A is IERC721A {
         address to,
         uint24 previousExtraData
     ) internal view virtual returns (uint24) {}
+
+    /**
+     * @dev Returns the next extra data for the packed ownership data.
+     * The returned result is shifted into position.
+     */
+    function _nextExtraData(
+        address from,
+        address to,
+        uint256 prevOwnershipPacked
+    ) private view returns (uint256) {
+        uint24 extraData = uint24(prevOwnershipPacked >> _BITPOS_EXTRA_DATA);
+        return uint256(_extraData(from, to, extraData)) << _BITPOS_EXTRA_DATA;
+    }
 
     // =============================================================
     //                       OTHER OPERATIONS

--- a/contracts/IERC721A.sol
+++ b/contracts/IERC721A.sol
@@ -79,6 +79,10 @@ interface IERC721A {
      */
     error OwnershipNotInitializedForExtraData();
 
+    // =============================================================
+    //                            STRUCTS
+    // =============================================================
+
     struct TokenOwnership {
         // The address of the owner.
         address addr;
@@ -90,6 +94,10 @@ interface IERC721A {
         uint24 extraData;
     }
 
+    // =============================================================
+    //                         TOKEN COUNTERS
+    // =============================================================
+
     /**
      * @dev Returns the total number of tokens in existence.
      * Burned tokens will reduce the count.
@@ -97,9 +105,9 @@ interface IERC721A {
      */
     function totalSupply() external view returns (uint256);
 
-    // ==============================
-    //            IERC165
-    // ==============================
+    // =============================================================
+    //                            IERC165
+    // =============================================================
 
     /**
      * @dev Returns true if this contract implements the interface defined by
@@ -111,9 +119,9 @@ interface IERC721A {
      */
     function supportsInterface(bytes4 interfaceId) external view returns (bool);
 
-    // ==============================
-    //            IERC721
-    // ==============================
+    // =============================================================
+    //                            IERC721
+    // =============================================================
 
     /**
      * @dev Emitted when `tokenId` token is transferred from `from` to `to`.
@@ -245,9 +253,9 @@ interface IERC721A {
      */
     function isApprovedForAll(address owner, address operator) external view returns (bool);
 
-    // ==============================
-    //        IERC721Metadata
-    // ==============================
+    // =============================================================
+    //                        IERC721Metadata
+    // =============================================================
 
     /**
      * @dev Returns the token collection name.
@@ -264,9 +272,9 @@ interface IERC721A {
      */
     function tokenURI(uint256 tokenId) external view returns (string memory);
 
-    // ==============================
-    //            IERC2309
-    // ==============================
+    // =============================================================
+    //                           IERC2309
+    // =============================================================
 
     /**
      * @dev Emitted when tokens in `fromTokenId` to `toTokenId`

--- a/contracts/IERC721A.sol
+++ b/contracts/IERC721A.sol
@@ -156,9 +156,9 @@ interface IERC721A {
      * - `to` cannot be the zero address.
      * - `tokenId` token must exist and be owned by `from`.
      * - If the caller is not `from`, it must be have been allowed to move
-     *   this token by either {approve} or {setApprovalForAll}.
+     * this token by either {approve} or {setApprovalForAll}.
      * - If `to` refers to a smart contract, it must implement
-     *   {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     * {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
      *
      * Emits a {Transfer} event.
      */
@@ -190,7 +190,7 @@ interface IERC721A {
      * - `to` cannot be the zero address.
      * - `tokenId` token must be owned by `from`.
      * - If the caller is not `from`, it must be approved to move this token
-     *   by either {approve} or {setApprovalForAll}.
+     * by either {approve} or {setApprovalForAll}.
      *
      * Emits a {Transfer} event.
      */

--- a/contracts/IERC721A.sol
+++ b/contracts/IERC721A.sol
@@ -179,7 +179,7 @@ interface IERC721A {
     ) external;
 
     /**
-     * @dev Transfers `tokenId` token from `from` to `to`.
+     * @dev Transfers `tokenId` from `from` to `to`.
      *
      * WARNING: Usage of this method is discouraged, use {safeTransferFrom}
      * whenever possible.

--- a/contracts/IERC721A.sol
+++ b/contracts/IERC721A.sol
@@ -5,7 +5,7 @@
 pragma solidity ^0.8.4;
 
 /**
- * @dev Interface of an ERC721A compliant contract.
+ * @dev Interface of ERC721A.
  */
 interface IERC721A {
     /**
@@ -54,7 +54,8 @@ interface IERC721A {
     error TransferFromIncorrectOwner();
 
     /**
-     * Cannot safely transfer to a contract that does not implement the ERC721Receiver interface.
+     * Cannot safely transfer to a contract that does not implement the
+     * ERC721Receiver interface.
      */
     error TransferToNonERC721ReceiverImplementer();
 
@@ -81,18 +82,18 @@ interface IERC721A {
     struct TokenOwnership {
         // The address of the owner.
         address addr;
-        // Keeps track of the start time of ownership with minimal overhead for tokenomics.
+        // Stores the start time of ownership with minimal overhead for tokenomics.
         uint64 startTimestamp;
         // Whether the token has been burned.
         bool burned;
-        // Arbitrary data similar to `startTimestamp` that can be set through `_extraData`.
+        // Arbitrary data similar to `startTimestamp` that can be set via {_extraData}.
         uint24 extraData;
     }
 
     /**
-     * @dev Returns the total amount of tokens stored by the contract.
-     *
-     * Burned tokens are calculated here, use `_totalMinted()` if you want to count just minted tokens.
+     * @dev Returns the total number of tokens in existence.
+     * Burned tokens will reduce the count.
+     * To get the total number of tokens minted, please see {_totalMinted}.
      */
     function totalSupply() external view returns (uint256);
 
@@ -103,10 +104,10 @@ interface IERC721A {
     /**
      * @dev Returns true if this contract implements the interface defined by
      * `interfaceId`. See the corresponding
-     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
+     * [EIP section](https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified)
      * to learn more about how these ids are created.
      *
-     * This function call must use less than 30 000 gas.
+     * This function call must use less than 30000 gas.
      */
     function supportsInterface(bytes4 interfaceId) external view returns (bool);
 
@@ -125,12 +126,13 @@ interface IERC721A {
     event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
 
     /**
-     * @dev Emitted when `owner` enables or disables (`approved`) `operator` to manage all of its assets.
+     * @dev Emitted when `owner` enables or disables
+     * (`approved`) `operator` to manage all of its assets.
      */
     event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
 
     /**
-     * @dev Returns the number of tokens in ``owner``'s account.
+     * @dev Returns the number of tokens in `owner`'s account.
      */
     function balanceOf(address owner) external view returns (uint256 balance);
 
@@ -144,15 +146,19 @@ interface IERC721A {
     function ownerOf(uint256 tokenId) external view returns (address owner);
 
     /**
-     * @dev Safely transfers `tokenId` token from `from` to `to`.
+     * @dev Safely transfers `tokenId` token from `from` to `to`,
+     * checking first that contract recipients are aware of the ERC721 protocol
+     * to prevent tokens from being forever locked.
      *
      * Requirements:
      *
      * - `from` cannot be the zero address.
      * - `to` cannot be the zero address.
      * - `tokenId` token must exist and be owned by `from`.
-     * - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
-     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     * - If the caller is not `from`, it must be have been allowed to move
+     *   this token by either {approve} or {setApprovalForAll}.
+     * - If `to` refers to a smart contract, it must implement
+     *   {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
      *
      * Emits a {Transfer} event.
      */
@@ -164,18 +170,7 @@ interface IERC721A {
     ) external;
 
     /**
-     * @dev Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients
-     * are aware of the ERC721 protocol to prevent tokens from being forever locked.
-     *
-     * Requirements:
-     *
-     * - `from` cannot be the zero address.
-     * - `to` cannot be the zero address.
-     * - `tokenId` token must exist and be owned by `from`.
-     * - If the caller is not `from`, it must be have been allowed to move this token by either {approve} or {setApprovalForAll}.
-     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
-     *
-     * Emits a {Transfer} event.
+     * @dev Equivalent to `safeTransferFrom(from, to, tokenId, '')`.
      */
     function safeTransferFrom(
         address from,
@@ -186,14 +181,16 @@ interface IERC721A {
     /**
      * @dev Transfers `tokenId` token from `from` to `to`.
      *
-     * WARNING: Usage of this method is discouraged, use {safeTransferFrom} whenever possible.
+     * WARNING: Usage of this method is discouraged, use {safeTransferFrom}
+     * whenever possible.
      *
      * Requirements:
      *
      * - `from` cannot be the zero address.
      * - `to` cannot be the zero address.
      * - `tokenId` token must be owned by `from`.
-     * - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
+     * - If the caller is not `from`, it must be approved to move this token
+     *   by either {approve} or {setApprovalForAll}.
      *
      * Emits a {Transfer} event.
      */
@@ -207,7 +204,8 @@ interface IERC721A {
      * @dev Gives permission to `to` to transfer `tokenId` token to another account.
      * The approval is cleared when the token is transferred.
      *
-     * Only a single account can be approved at a time, so approving the zero address clears previous approvals.
+     * Only a single account can be approved at a time, so approving the
+     * zero address clears previous approvals.
      *
      * Requirements:
      *
@@ -220,7 +218,8 @@ interface IERC721A {
 
     /**
      * @dev Approve or remove `operator` as an operator for the caller.
-     * Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.
+     * Operators can call {transferFrom} or {safeTransferFrom}
+     * for any token owned by the caller.
      *
      * Requirements:
      *
@@ -242,7 +241,7 @@ interface IERC721A {
     /**
      * @dev Returns if the `operator` is allowed to manage all of the assets of `owner`.
      *
-     * See {setApprovalForAll}
+     * See {setApprovalForAll}.
      */
     function isApprovedForAll(address owner, address operator) external view returns (bool);
 
@@ -270,8 +269,11 @@ interface IERC721A {
     // ==============================
 
     /**
-     * @dev Emitted when tokens in `fromTokenId` to `toTokenId` (inclusive) is transferred from `from` to `to`,
-     * as defined in the ERC2309 standard. See `_mintERC2309` for more details.
+     * @dev Emitted when tokens in `fromTokenId` to `toTokenId`
+     * (inclusive) is transferred from `from` to `to`, as defined in the
+     * [ERC2309](https://eips.ethereum.org/EIPS/eip-2309) standard.
+     *
+     * See {_mintERC2309} for more details.
      */
     event ConsecutiveTransfer(uint256 indexed fromTokenId, uint256 toTokenId, address indexed from, address indexed to);
 }

--- a/contracts/extensions/ERC721ABurnable.sol
+++ b/contracts/extensions/ERC721ABurnable.sol
@@ -8,8 +8,9 @@ import './IERC721ABurnable.sol';
 import '../ERC721A.sol';
 
 /**
- * @title ERC721A Burnable Token
- * @dev ERC721A Token that can be irreversibly burned (destroyed).
+ * @title ERC721ABurnable.
+ *
+ * @dev ERC721A token that can be irreversibly burned (destroyed).
  */
 abstract contract ERC721ABurnable is ERC721A, IERC721ABurnable {
     /**

--- a/contracts/extensions/ERC721AQueryable.sol
+++ b/contracts/extensions/ERC721AQueryable.sol
@@ -8,7 +8,8 @@ import './IERC721AQueryable.sol';
 import '../ERC721A.sol';
 
 /**
- * @title ERC721A Queryable
+ * @title ERC721AQueryable.
+ *
  * @dev ERC721A subclass with convenience query functions.
  */
 abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
@@ -16,22 +17,25 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
      * @dev Returns the `TokenOwnership` struct at `tokenId` without reverting.
      *
      * If the `tokenId` is out of bounds:
-     *   - `addr` = `address(0)`
-     *   - `startTimestamp` = `0`
-     *   - `burned` = `false`
-     *   - `extraData` = `0`
+     *
+     * - `addr = address(0)`
+     * - `startTimestamp = 0`
+     * - `burned = false`
+     * - `extraData = 0`
      *
      * If the `tokenId` is burned:
-     *   - `addr` = `<Address of owner before token was burned>`
-     *   - `startTimestamp` = `<Timestamp when token was burned>`
-     *   - `burned = `true`
-     *   - `extraData` = `<Extra data when token was burned>`
+     *
+     * - `addr = <Address of owner before token was burned>`
+     * - `startTimestamp = <Timestamp when token was burned>`
+     * - `burned = true`
+     * - `extraData = <Extra data when token was burned>`
      *
      * Otherwise:
-     *   - `addr` = `<Address of owner>`
-     *   - `startTimestamp` = `<Timestamp of start of ownership>`
-     *   - `burned = `false`
-     *   - `extraData` = `<Extra data at start of ownership>`
+     *
+     * - `addr = <Address of owner>`
+     * - `startTimestamp = <Timestamp of start of ownership>`
+     * - `burned = false`
+     * - `extraData = <Extra data at start of ownership>`
      */
     function explicitOwnershipOf(uint256 tokenId) public view virtual override returns (TokenOwnership memory) {
         TokenOwnership memory ownership;
@@ -76,7 +80,7 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
      *
      * Requirements:
      *
-     * - `start` < `stop`
+     * - `start < stop`
      */
     function tokensOfOwnerIn(
         address owner,
@@ -142,12 +146,12 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
     /**
      * @dev Returns an array of token IDs owned by `owner`.
      *
-     * This function scans the ownership mapping and is O(totalSupply) in complexity.
+     * This function scans the ownership mapping and is O(`totalSupply`) in complexity.
      * It is meant to be called off-chain.
      *
      * See {ERC721AQueryable-tokensOfOwnerIn} for splitting the scan into
      * multiple smaller scans if the collection is large enough to cause
-     * an out-of-gas error (10K pfp collections should be fine).
+     * an out-of-gas error (10K collections should be fine).
      */
     function tokensOfOwner(address owner) external view virtual override returns (uint256[] memory) {
         unchecked {

--- a/contracts/extensions/IERC721ABurnable.sol
+++ b/contracts/extensions/IERC721ABurnable.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.8.4;
 import '../IERC721A.sol';
 
 /**
- * @dev Interface of an ERC721ABurnable compliant contract.
+ * @dev Interface of ERC721ABurnable.
  */
 interface IERC721ABurnable is IERC721A {
     /**

--- a/contracts/extensions/IERC721AQueryable.sol
+++ b/contracts/extensions/IERC721AQueryable.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.8.4;
 import '../IERC721A.sol';
 
 /**
- * @dev Interface of an ERC721AQueryable compliant contract.
+ * @dev Interface of ERC721AQueryable.
  */
 interface IERC721AQueryable is IERC721A {
     /**
@@ -19,19 +19,25 @@ interface IERC721AQueryable is IERC721A {
      * @dev Returns the `TokenOwnership` struct at `tokenId` without reverting.
      *
      * If the `tokenId` is out of bounds:
-     *   - `addr` = `address(0)`
-     *   - `startTimestamp` = `0`
-     *   - `burned` = `false`
+     *
+     * - `addr = address(0)`
+     * - `startTimestamp = 0`
+     * - `burned = false`
+     * - `extraData = 0`
      *
      * If the `tokenId` is burned:
-     *   - `addr` = `<Address of owner before token was burned>`
-     *   - `startTimestamp` = `<Timestamp when token was burned>`
-     *   - `burned = `true`
+     *
+     * - `addr = <Address of owner before token was burned>`
+     * - `startTimestamp = <Timestamp when token was burned>`
+     * - `burned = true`
+     * - `extraData = <Extra data when token was burned>`
      *
      * Otherwise:
-     *   - `addr` = `<Address of owner>`
-     *   - `startTimestamp` = `<Timestamp of start of ownership>`
-     *   - `burned = `false`
+     *
+     * - `addr = <Address of owner>`
+     * - `startTimestamp = <Timestamp of start of ownership>`
+     * - `burned = false`
+     * - `extraData = <Extra data at start of ownership>`
      */
     function explicitOwnershipOf(uint256 tokenId) external view returns (TokenOwnership memory);
 
@@ -51,7 +57,7 @@ interface IERC721AQueryable is IERC721A {
      *
      * Requirements:
      *
-     * - `start` < `stop`
+     * - `start < stop`
      */
     function tokensOfOwnerIn(
         address owner,
@@ -62,12 +68,12 @@ interface IERC721AQueryable is IERC721A {
     /**
      * @dev Returns an array of token IDs owned by `owner`.
      *
-     * This function scans the ownership mapping and is O(totalSupply) in complexity.
+     * This function scans the ownership mapping and is O(`totalSupply`) in complexity.
      * It is meant to be called off-chain.
      *
      * See {ERC721AQueryable-tokensOfOwnerIn} for splitting the scan into
      * multiple smaller scans if the collection is large enough to cause
-     * an out-of-gas error (10K pfp collections should be fine).
+     * an out-of-gas error (10K collections should be fine).
      */
     function tokensOfOwner(address owner) external view returns (uint256[] memory);
 }

--- a/contracts/mocks/ERC721ReceiverMock.sol
+++ b/contracts/mocks/ERC721ReceiverMock.sol
@@ -35,7 +35,7 @@ contract ERC721ReceiverMock is ERC721A__IERC721Receiver {
         bytes memory data
     ) public override returns (bytes4) {
         uint256 dataValue = data.length == 0 ? 0 : uint256(uint8(data[0]));
-        
+
         // For testing reverts with a message from the receiver contract.
         if (dataValue == 0x01) {
             revert('reverted in the receiver contract!');


### PR DESCRIPTION
Changes:

- Basically inline some comments, shorten them if possible, standardize the grammar, fix inconsistent punctuation, etc. 

- Structured `ERC721A.sol` into sections.

- Renamed the following private functions in `ERC721A.sol` for clarity:

  - `_isOwnerOrApproved` -> `_isSenderApprovedOrOwner`.
  
  - `_getApprovedAddress` -> `_getApprovedSlotAndAddress`.
  
To be determined:

- Change linter to use double quotes for Solidity (to keep in line with the official style guidelines)?