### PR TITLE
Fix "error:0308010C:digital envelope routines::unsupported"

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [14.x,17.x,18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x,17.x,18.x]
+        node-version: [14.x,16.x,17.x,18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -29,3 +29,17 @@ module.exports = {
   },
   plugins: ['solidity-coverage'],
 };
+
+// The "ripemd160" algorithm is not available anymore in NodeJS 17+ (because of lib SSL 3).
+// The following code replaces it with "sha256" instead.
+
+const crypto = require('crypto');
+
+try {
+  crypto.createHash('ripemd160');
+} catch (e) {
+  const origCreateHash = crypto.createHash;
+  crypto.createHash = (alg, opts) => {
+    return origCreateHash(alg === 'ripemd160' ? 'sha256' : alg, opts);
+  };
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "/build/contracts/*.json",
     "!/contracts/mocks/**/*"
   ],
+  "engines": {
+    "node": ">=16.0.0 <17.0.0"
+  },
   "scripts": {
     "node": "hardhat node",
     "test": "hardhat test",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "/build/contracts/*.json",
     "!/contracts/mocks/**/*"
   ],
-  "engines": {
-    "node": ">=16.0.0 <17.0.0"
-  },
   "scripts": {
     "node": "hardhat node",
     "test": "hardhat test",


### PR DESCRIPTION
When I have cloned the repo, I proceeded to use node versions 18 and 17 to run tests. Which both failed due to the SSL breaking change in 17 & 18.

Solution is to use node version 16.