### PR TITLE
CI tests workflow fix

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x,16.x,17.x,18.x]
+        node-version: [14.x,16.x,17.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Somehow Node 18 fails in CI. 

Let's remove it for now and see how it goes.