### PR TITLE
Update minor comment in ERC721A.sol

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -515,7 +515,7 @@ contract ERC721A is IERC721A {
         returns (uint256 approvedAddressSlot, address approvedAddress)
     {
         TokenApprovalRef storage tokenApproval = _tokenApprovals[tokenId];
-        // The following is equivalent to `approvedAddress = _tokenApprovals[tokenId]`.
+        // The following is equivalent to `approvedAddress = _tokenApprovals[tokenId].value`.
         assembly {
             approvedAddressSlot := tokenApproval.slot
             approvedAddress := sload(approvedAddressSlot)


### PR DESCRIPTION
Fix comment in _getApprovedSlotAndAddress that describes the assembly code.

It is equivalent to `approvedAddress = _tokenApprovals[tokenId].value` and not `approvedAddress = _tokenApprovals[tokenId]`