### PR TITLE
Comments on the assembly mint loop

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -763,8 +763,8 @@ contract ERC721A is IERC721A {
             uint256 end = startTokenId + quantity;
 
             // Use assembly to loop and emit the `Transfer` event for gas savings.
-            // The duplicated `log4` helps removes an extra check and reduce stack juggling.
-            // Operations are delicately balanced and arranged for compiler friendlyness.
+            // The duplicated `log4` removes an extra check and reduces stack juggling.
+            // Delicately arranged to nudge the compiler into producing optimized opcode.
             assembly {
                 // Mask `to` to the lower 160 bits, in case the upper bits somehow aren't clean.
                 toMasked := and(to, _BITMASK_ADDRESS)

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -763,6 +763,8 @@ contract ERC721A is IERC721A {
             uint256 end = startTokenId + quantity;
 
             // Use assembly to loop and emit the `Transfer` event for gas savings.
+            // The duplicated `log4` helps removes an extra check and reduce stack juggling.
+            // Operations are delicately balanced and arranged for compiler friendlyness.
             assembly {
                 // Mask `to` to the lower 160 bits, in case the upper bits somehow aren't clean.
                 toMasked := and(to, _BITMASK_ADDRESS)

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -764,7 +764,8 @@ contract ERC721A is IERC721A {
 
             // Use assembly to loop and emit the `Transfer` event for gas savings.
             // The duplicated `log4` removes an extra check and reduces stack juggling.
-            // Delicately arranged to nudge the compiler into producing optimized opcode.
+            // The assembly, together with the surrounding Solidity code, have been
+            // delicately arranged to nudge the compiler into producing optimized opcodes.
             assembly {
                 // Mask `to` to the lower 160 bits, in case the upper bits somehow aren't clean.
                 toMasked := and(to, _BITMASK_ADDRESS)

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -1052,7 +1052,7 @@ contract ERC721A is IERC721A {
     function _toString(uint256 value) internal pure virtual returns (string memory str) {
         assembly {
             // The maximum value of a uint256 contains 78 digits (1 byte per digit),
-            // but we allocate 0x80 bytes to keep the free memory pointer 32-byte word aliged.
+            // but we allocate 0x80 bytes to keep the free memory pointer 32-byte word aligned.
             // We will need 1 32-byte word to store the length,
             // and 3 32-byte words to store a maximum of 78 digits. Total: 0x20 + 3 * 0x20 = 0x80.
             str := add(mload(0x40), 0x80)


### PR DESCRIPTION
I've also tried the trick of 

```solidity
assembly {
    // Mask `to` to the lower 160 bits, in case the upper bits somehow aren't clean.
    toMasked := and(to, _BITMASK_ADDRESS)

    for {} 1 {} {
        // Emit the `Transfer` event.
        log4(
            0, // Start of data (0, since no data).
            0, // End of data (0, since no data).
            _TRANSFER_EVENT_SIGNATURE, // Signature.
            0, // `address(0)`.
            toMasked, // `to`.
            startTokenId // `tokenId`.
        )
        startTokenId := add(startTokenId, 1)
        if iszero(lt(startTokenId, end)) { break }
    }
}
```

But that costs 56179 instead of 56165 for minting 1, and 73563 instead of 73540 for minting 10.

Multiply that tiny gas savings across thousands of mints, and with many free mints (e.g. Goblintown) only minting 1 or 2 NFTs, the current code is still quite preferred. 