### PR TITLE
Fix _toString comment typo

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -515,7 +515,7 @@ contract ERC721A is IERC721A {
         returns (uint256 approvedAddressSlot, address approvedAddress)
     {
         TokenApprovalRef storage tokenApproval = _tokenApprovals[tokenId];
-        // The following is equivalent to `approvedAddress = _tokenApprovals[tokenId]`.
+        // The following is equivalent to `approvedAddress = _tokenApprovals[tokenId].value`.
         assembly {
             approvedAddressSlot := tokenApproval.slot
             approvedAddress := sload(approvedAddressSlot)

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -1049,7 +1049,7 @@ contract ERC721A is IERC721A {
     function _toString(uint256 value) internal pure virtual returns (string memory str) {
         assembly {
             // The maximum value of a uint256 contains 78 digits (1 byte per digit),
-            // but we allocate 0x80 bytes to keep the free memory pointer 32-byte word aliged.
+            // but we allocate 0x80 bytes to keep the free memory pointer 32-byte word aligned.
             // We will need 1 32-byte word to store the length,
             // and 3 32-byte words to store a maximum of 78 digits. Total: 0x20 + 3 * 0x20 = 0x80.
             str := add(mload(0x40), 0x80)

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -766,23 +766,21 @@ contract ERC721A is IERC721A {
             assembly {
                 // Mask `to` to the lower 160 bits, in case the upper bits somehow aren't clean.
                 toMasked := and(to, _BITMASK_ADDRESS)
-                // Emit the `Transfer` event.
-                log4(
-                    0, // Start of data (0, since no data).
-                    0, // End of data (0, since no data).
-                    _TRANSFER_EVENT_SIGNATURE, // Signature.
-                    0, // `address(0)`.
-                    toMasked, // `to`.
-                    startTokenId // `tokenId`.
-                )
 
                 for {
-                    let tokenId := add(startTokenId, 1)
+                    let tokenId := startTokenId
                 } iszero(eq(tokenId, end)) {
                     tokenId := add(tokenId, 1)
                 } {
-                    // Emit the `Transfer` event. Similar to above.
-                    log4(0, 0, _TRANSFER_EVENT_SIGNATURE, 0, toMasked, tokenId)
+                    // Emit the `Transfer` event.
+                    log4(
+                        0, // Start of data (0, since no data).
+                        0, // End of data (0, since no data).
+                        _TRANSFER_EVENT_SIGNATURE, // Signature.
+                        0, // `address(0)`.
+                        toMasked, // `to`.
+                        tokenId // `tokenId`.
+                    )
                 }
             }
             if (toMasked == 0) revert MintToZeroAddress();

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -766,21 +766,23 @@ contract ERC721A is IERC721A {
             assembly {
                 // Mask `to` to the lower 160 bits, in case the upper bits somehow aren't clean.
                 toMasked := and(to, _BITMASK_ADDRESS)
+                // Emit the `Transfer` event.
+                log4(
+                    0, // Start of data (0, since no data).
+                    0, // End of data (0, since no data).
+                    _TRANSFER_EVENT_SIGNATURE, // Signature.
+                    0, // `address(0)`.
+                    toMasked, // `to`.
+                    startTokenId // `tokenId`.
+                )
 
                 for {
-                    let tokenId := startTokenId
+                    let tokenId := add(startTokenId, 1)
                 } iszero(eq(tokenId, end)) {
                     tokenId := add(tokenId, 1)
                 } {
-                    // Emit the `Transfer` event.
-                    log4(
-                        0, // Start of data (0, since no data).
-                        0, // End of data (0, since no data).
-                        _TRANSFER_EVENT_SIGNATURE, // Signature.
-                        0, // `address(0)`.
-                        toMasked, // `to`.
-                        tokenId // `tokenId`.
-                    )
+                    // Emit the `Transfer` event. Similar to above.
+                    log4(0, 0, _TRANSFER_EVENT_SIGNATURE, 0, toMasked, tokenId)
                 }
             }
             if (toMasked == 0) revert MintToZeroAddress();


### PR DESCRIPTION
Question: why does the memory pointer have to be 32-byte aligned? I ran the code reserving exactly 78+32 bytes `str := add(mload(0x40), 0x6C)`, and the execution of the function cost 3 less gas.