### PR TITLE
caller or token owner should be able to approve self as operator for …

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -459,8 +459,6 @@ contract ERC721A is IERC721A {
      * Emits an {ApprovalForAll} event.
      */
     function setApprovalForAll(address operator, bool approved) public virtual override {
-        if (operator == _msgSenderERC721A()) revert ApproveToCaller();
-
         _operatorApprovals[_msgSenderERC721A()][operator] = approved;
         emit ApprovalForAll(_msgSenderERC721A(), operator, approved);
     }

--- a/contracts/IERC721A.sol
+++ b/contracts/IERC721A.sol
@@ -19,11 +19,6 @@ interface IERC721A {
     error ApprovalQueryForNonexistentToken();
 
     /**
-     * The caller cannot approve to their own address.
-     */
-    error ApproveToCaller();
-
-    /**
      * Cannot query the balance for the zero address.
      */
     error BalanceQueryForZeroAddress();

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -295,11 +295,15 @@ const createTestSuite = ({ contract, constructorArgs }) =>
           });
 
           it('caller can approve all with self as operator', async function () {
-            expect(await this.erc721a.connect(this.addr1).isApprovedForAll(this.addr1.address, this.addr1.address)).to.be.false;
+            expect(
+              await this.erc721a.connect(this.addr1).isApprovedForAll(this.addr1.address, this.addr1.address)
+            ).to.be.false;
             await expect(
               this.erc721a.connect(this.addr1).setApprovalForAll(this.addr1.address, true)
             ).to.not.be.reverted;
-            expect(await this.erc721a.connect(this.addr1).isApprovedForAll(this.addr1.address, this.addr1.address)).to.be.true;
+            expect(
+              await this.erc721a.connect(this.addr1).isApprovedForAll(this.addr1.address, this.addr1.address)
+            ).to.be.true;
           });
         });
 

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -268,6 +268,21 @@ const createTestSuite = ({ contract, constructorArgs }) =>
               this.erc721a.connect(this.addr1).transferFrom(this.addr3.address, this.addr1.address, this.tokenId)
             ).to.be.revertedWith('TransferCallerNotOwnerNorApproved');
           });
+
+          it('token owner can approve self as operator', async function () {
+		    expect(await this.erc721a.getApproved(this.tokenId)).to.not.equal(this.addr1.address);
+            await expect(this.erc721a.connect(this.addr1).approve(this.addr1.address, this.tokenId)
+            ).to.not.be.reverted;
+            expect(await this.erc721a.getApproved(this.tokenId)).to.equal(this.addr1.address);
+          });
+
+          it('self-approval is cleared on token transfer', async function () {
+            await this.erc721a.connect(this.addr1).approve(this.addr1.address, this.tokenId); 
+            expect(await this.erc721a.getApproved(this.tokenId)).to.equal(this.addr1.address);
+
+            await this.erc721a.connect(this.addr1).transferFrom(this.addr1.address, this.addr2.address, this.tokenId);
+            expect(await this.erc721a.getApproved(this.tokenId)).to.not.equal(this.addr1.address);
+          });
         });
 
         describe('setApprovalForAll', async function () {
@@ -279,10 +294,12 @@ const createTestSuite = ({ contract, constructorArgs }) =>
             expect(await this.erc721a.isApprovedForAll(this.owner.address, this.addr1.address)).to.be.true;
           });
 
-          it('sets rejects approvals for non msg senders', async function () {
+          it('caller can approve all with self as operator', async function () {
+            expect(await this.erc721a.connect(this.addr1).isApprovedForAll(this.addr1.address, this.addr1.address)).to.be.false;
             await expect(
               this.erc721a.connect(this.addr1).setApprovalForAll(this.addr1.address, true)
-            ).to.be.revertedWith('ApproveToCaller');
+            ).to.not.be.reverted;
+            expect(await this.erc721a.connect(this.addr1).isApprovedForAll(this.addr1.address, this.addr1.address)).to.be.true;
           });
         });
 
@@ -455,6 +472,12 @@ const createTestSuite = ({ contract, constructorArgs }) =>
           });
 
           it('can burn without approvalCheck parameter', async function () {
+            expect(await this.erc721a.exists(this.tokenIdToBurn)).to.be.true;
+            await this.erc721a.connect(this.addr2)['burn(uint256)'](this.tokenIdToBurn);
+            expect(await this.erc721a.exists(this.tokenIdToBurn)).to.be.false;
+          });
+
+          it('cannot burn a token owned by another if not approved', async function () {
             expect(await this.erc721a.exists(this.tokenIdToBurn)).to.be.true;
             await this.erc721a.connect(this.addr2)['burn(uint256)'](this.tokenIdToBurn);
             expect(await this.erc721a.exists(this.tokenIdToBurn)).to.be.false;

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -270,7 +270,7 @@ const createTestSuite = ({ contract, constructorArgs }) =>
           });
 
           it('token owner can approve self as operator', async function () {
-		    expect(await this.erc721a.getApproved(this.tokenId)).to.not.equal(this.addr1.address);
+            expect(await this.erc721a.getApproved(this.tokenId)).to.not.equal(this.addr1.address);
             await expect(this.erc721a.connect(this.addr1).approve(this.addr1.address, this.tokenId)
             ).to.not.be.reverted;
             expect(await this.erc721a.getApproved(this.tokenId)).to.equal(this.addr1.address);


### PR DESCRIPTION
…own tokens. 

**Motivation:** 
As discussed, the EIP doesn't explicitly state that someone can't be their own operator for their own tokens. It has no effect per se, other than clearing any existing operator for the same tokens. An address being its own approver does no harm, and does not seem to be explicitly forbidden by the EIP. 

approve(my_address, my_token_id) -> results in getApproved(my_token_id) returning the address of the owner. Now the token owner has all the same rights that they already had anyway. 

Same for setApprovalForAll(my_address) -> the token owner is now the operator for all of its own tokens. 

**Changes**
- removed check for (operator == sender) in setApprovalForAll. 
- removed error ApproveToCaller (no longer being used) 
- modified unit test that was testing for that error, to check instead that the call is not reverted. 
- and then modified that same test to check that isApprovedForAll returns true for the token owner 
- added a new test in "setApprovalForAll" to check that similarly, an address can call approve to set itself as operator for its own tokens 
- added a further test that, once an address has called approve to set itself as operator, transferring will clear the approval (as it would for any other operator) 