### PR TITLE
The Soulbound NFT is burnable but non-transferable and becomes part of the owner's web3 identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ _We highly recommend reading the migration guide_, **especially** _the part on [
 
 ## About The Project
 
+### Soulbound NFTs
+This fork of [ERC721A](https://github.com/chiru-labs/ERC721A) is an implementation of an SBT (Soulbound NFT) or a non-transferable NFT (NTT). This token is soulbound to the owner of the token at mint. The token owner is able to burn their token at will.
+
+Soulbound NFTs are an ideal methodology for creating a web3 identity. A community member's web3 identity will be curated from token present on their wallet. 
+
+The current trend of NFT projects is to move away from a members club into a DAO or other community govern society. These newly forming decentralized societies are often govern by the largest financial interest, this metric is not a good measure of societial value as it doesn't account for humanitian metrics like environmental impact and compassion.
+
+A Soulbound NFT ensures credibility, reputation and experience is not bought by the highest bidder. A community member's societial value can be determined by their web3 identity made of non-transferable SBTs.
+
+### ERC721A
 The goal of ERC721A is to provide a fully compliant implementation of IERC721 with significant gas savings for minting multiple NFTs in a single transaction. This project and implementation will be updated regularly and will continue to stay up to date with best practices.
 
 The [Azuki](https://twitter.com/AzukiOfficial) team created ERC721A for its sale on 1/12/22. There was significant demand for 8700 tokens made available to the public, and all were minted within minutes. The network BASEFEE remained low despite huge demand, resulting in low gas costs for minters, while minimizing network disruption for the wider ecosystem as well.

--- a/contracts/extensions/ERC721ASoulbound.sol
+++ b/contracts/extensions/ERC721ASoulbound.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+// ERC721A Contracts v4.2.2
+// Creator: Chiru Labs
+
+pragma solidity ^0.8.4;
+
+import './IERC721ASoulbound.sol';
+import './ERC721ABurnable.sol';
+
+/**
+ * @title ERC721ASoulbound.
+ *
+ * @dev ERC721A token that is non-transferable.
+ */
+abstract contract ERC721ASoulbound is ERC721ABurnable, IERC721ASoulbound {
+    /**
+     * @dev Overrides _beforeTokenTransfers to make token non-transferable. The token is till mintable, and burnable.
+     *
+     * Requirements:
+     *
+     * - The caller must own `tokenId` or be an approved operator.
+     */
+    function _beforeTokenTransfers(
+        address from,
+        address to,
+        uint256 startTokenId,
+        uint256 quantity
+    ) internal virtual override {
+        if (from != address(0)) 
+            if (to != address(0)) 
+            revert SoulboundTokenCannotBeTransferred();
+    }
+}

--- a/contracts/extensions/IERC721ASoulbound.sol
+++ b/contracts/extensions/IERC721ASoulbound.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+// ERC721A Contracts v4.2.2
+// Creator: Chiru Labs
+
+pragma solidity ^0.8.4;
+
+import './IERC721ABurnable.sol';
+
+/**
+ * @dev Interface of ERC721ASoulbound.
+ */
+interface IERC721ASoulbound is IERC721ABurnable {
+    /**
+     * A Soulbound token cannot be transferred.
+     */
+    error SoulboundTokenCannotBeTransferred();
+}

--- a/contracts/interfaces/IERC721ASoulbound.sol
+++ b/contracts/interfaces/IERC721ASoulbound.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+// ERC721A Contracts v4.2.2
+// Creator: Chiru Labs
+
+pragma solidity ^0.8.4;
+
+import './IERC721ABurnable.sol';
+
+/**
+ * @dev Interface of ERC721ASoulbound.
+ */
+interface IERC721ASoulbound is IERC721ABurnable {
+    /**
+     * A Soulbound token cannot be transferred.
+     */
+    error SoulboundTokenCannotBeTransferred();
+}

--- a/contracts/mocks/ERC721ASoulboundMock.sol
+++ b/contracts/mocks/ERC721ASoulboundMock.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+// ERC721A Contracts v4.2.2
+// Creators: Chiru Labs
+
+pragma solidity ^0.8.4;
+
+import '../extensions/ERC721ASoulbound.sol';
+
+contract ERC721ASoulboundMock is ERC721ASoulbound {
+    constructor(string memory name_, string memory symbol_) ERC721A(name_, symbol_) {}
+
+    function safeMint(address to, uint256 quantity) public {
+        _safeMint(to, quantity);
+    }
+}

--- a/test/extensions/ERC721ASoulbound.test.js
+++ b/test/extensions/ERC721ASoulbound.test.js
@@ -1,0 +1,45 @@
+const { deployContract, getBlockTimestamp, mineBlockTimestamp, offsettedIndex } = require('../helpers.js');
+const { expect } = require('chai');
+const { constants } = require('@openzeppelin/test-helpers');
+const { ZERO_ADDRESS } = constants;
+
+const createTestSuite = ({ contract, constructorArgs }) =>
+  function () {
+    let offsetted;
+
+    context(`${contract}`, function () {
+      beforeEach(async function () {
+        this.erc721aSoulbound = await deployContract(contract, constructorArgs);
+
+        this.startTokenId = this.erc721aSoulbound.startTokenId
+          ? (await this.erc721aSoulbound.startTokenId()).toNumber()
+          : 0;
+
+        offsetted = (...arr) => offsettedIndex(this.startTokenId, arr);
+      });
+
+      beforeEach(async function () {
+        const [owner, addr1, addr2, spender] = await ethers.getSigners();
+        this.owner = owner;
+        this.addr1 = addr1;
+        this.addr2 = addr2;
+        this.spender = spender;
+        this.numTestTokens = 10;
+        this.burnedTokenId = 5;
+        this.notBurnedTokenId = 6;
+        await this.erc721aSoulbound['safeMint(address,uint256)'](this.addr1.address, this.numTestTokens);
+        await this.erc721aSoulbound.connect(this.addr1).burn(this.burnedTokenId);
+      });
+
+      it('cannot transfer token', async function () {
+        await expect(
+          this.erc721aSoulbound.connect(this.addr1).transferFrom(this.addr1.address, this.addr2.address, 6)
+        ).to.be.revertedWith('SoulboundTokenCannotBeTransferred');
+      });
+    });
+  };
+
+describe.only(
+  'ERC721ASoulbound',
+  createTestSuite({ contract: 'ERC721ASoulboundMock', constructorArgs: ['Azuki', 'AZUKI'] })
+);

--- a/test/extensions/ERC721ASoulbound.test.js
+++ b/test/extensions/ERC721ASoulbound.test.js
@@ -39,7 +39,7 @@ const createTestSuite = ({ contract, constructorArgs }) =>
     });
   };
 
-describe.only(
+describe(
   'ERC721ASoulbound',
   createTestSuite({ contract: 'ERC721ASoulboundMock', constructorArgs: ['Azuki', 'AZUKI'] })
 );


### PR DESCRIPTION
This PR is for the most basic implementation of a burnable & non-transferable [Soulbound NFT](https://vitalik.ca/general/2022/01/26/soulbound.html).

This implementation is to modify `_beforeTokenTransfers(from, to, startTokenId, quantity)` to only allow transfer to and from the null address.