### PR TITLE
Change startTokenId from 0 to 1.

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -152,7 +152,7 @@ contract ERC721A is IERC721A {
      * To change the starting token ID, please override this function.
      */
     function _startTokenId() internal view virtual returns (uint256) {
-        return 0;
+        return 1;
     }
 
     /**


### PR DESCRIPTION
You have to understand. Nobody, and I mean, Nobody starts their tokenIDs from 0. All the smart contracts I coded required me to override the function. Each. and. every. time.

Please just make it start from 1. Like, 90% of the projects out there start with tokenID 1.