### PR TITLE
Add trailing zeros padding to _toString

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -1049,13 +1049,17 @@ contract ERC721A is IERC721A {
      */
     function _toString(uint256 value) internal pure virtual returns (string memory str) {
         assembly {
-            // The maximum value of a uint256 contains 78 digits (1 byte per digit),
-            // but we allocate 0x80 bytes to keep the free memory pointer 32-byte word aligned.
-            // We will need 1 32-byte word to store the length,
-            // and 3 32-byte words to store a maximum of 78 digits. Total: 0x20 + 3 * 0x20 = 0x80.
-            str := add(mload(0x40), 0x80)
+            // The maximum value of a uint256 contains 78 digits (1 byte per digit), but
+            // we allocate 0xa0 bytes to keep the free memory pointer 32-byte word aligned.
+            // We will need 1 word for the trailing zeros padding, 1 word for the length,
+            // and 3 words for a maximum of 78 digits. Total: 5 * 0x20 = 0xa0.
+            let m := add(mload(0x40), 0xa0)
             // Update the free memory pointer to allocate.
-            mstore(0x40, str)
+            mstore(0x40, m)
+            // Assign the `str` to the end.
+            str := sub(m, 0x20)
+            // Zeroize the slot after the string.
+            mstore(str, 0)
 
             // Cache the end of the memory to calculate the length later.
             let end := str


### PR DESCRIPTION
When assembly is used to directly return the string (i.e. using `return(offset, length)` in Yul), it skips the built-in Solidity bookkeeping to copy and pad the string with zeros to the next word.

This can cause some issues with Etherscan decoding, like the `name()` function on [Seaport](https://etherscan.io/address/0x00000000006cee72100d161c57ada5bb2be1ca79#readContract).

Credits to @hrkrshnn for highlighting this obscure behavior.

This PR allocates an extra zeroed word to pad the string at the end, at the cost of a little additional gas. This is in case someone tries to use Yul to return strings.

Currently, using the unpadded `_toString` in plain Solidity, or in `abi.encodePacked`, or in `string.concat` will not cause any frontend issue. As long as devs don't use assembly to directly return the result of the unpadded `_toString`, the frontends will decode fine (probably near 100% of devs -- even I don't do manual assembly returns for strings).