### PR TITLE
Add payable gas optimization

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -422,7 +422,7 @@ contract ERC721A is IERC721A {
      *
      * Emits an {Approval} event.
      */
-    function approve(address to, uint256 tokenId) public virtual override {
+    function approve(address to, uint256 tokenId) public payable virtual override {
         address owner = ownerOf(tokenId);
 
         if (_msgSenderERC721A() != owner)
@@ -541,7 +541,7 @@ contract ERC721A is IERC721A {
         address from,
         address to,
         uint256 tokenId
-    ) public virtual override {
+    ) public payable virtual override {
         uint256 prevOwnershipPacked = _packedOwnershipOf(tokenId);
 
         if (address(uint160(prevOwnershipPacked)) != from) revert TransferFromIncorrectOwner();
@@ -607,7 +607,7 @@ contract ERC721A is IERC721A {
         address from,
         address to,
         uint256 tokenId
-    ) public virtual override {
+    ) public payable virtual override {
         safeTransferFrom(from, to, tokenId, '');
     }
 
@@ -631,7 +631,7 @@ contract ERC721A is IERC721A {
         address to,
         uint256 tokenId,
         bytes memory _data
-    ) public virtual override {
+    ) public payable virtual override {
         transferFrom(from, to, tokenId);
         if (to.code.length != 0)
             if (!_checkContractOnERC721Received(from, to, tokenId, _data)) {

--- a/contracts/IERC721A.sol
+++ b/contracts/IERC721A.sol
@@ -170,7 +170,7 @@ interface IERC721A {
         address to,
         uint256 tokenId,
         bytes calldata data
-    ) external;
+    ) external payable;
 
     /**
      * @dev Equivalent to `safeTransferFrom(from, to, tokenId, '')`.
@@ -179,7 +179,7 @@ interface IERC721A {
         address from,
         address to,
         uint256 tokenId
-    ) external;
+    ) external payable;
 
     /**
      * @dev Transfers `tokenId` from `from` to `to`.
@@ -201,7 +201,7 @@ interface IERC721A {
         address from,
         address to,
         uint256 tokenId
-    ) external;
+    ) external payable;
 
     /**
      * @dev Gives permission to `to` to transfer `tokenId` token to another account.
@@ -217,7 +217,7 @@ interface IERC721A {
      *
      * Emits an {Approval} event.
      */
-    function approve(address to, uint256 tokenId) external;
+    function approve(address to, uint256 tokenId) external payable;
 
     /**
      * @dev Approve or remove `operator` as an operator for the caller.


### PR DESCRIPTION
Based on https://eips.ethereum.org/EIPS/eip-721, the following functions can be made payable.

- `safeTransferFrom`
- `transferFrom`
- `approve`

Saves 24 gas for `transferFrom`.

Oh, poll here: https://twitter.com/optimizoor/status/1563757003809648640

A potential use case is for paid pull-based transfers.

Tbh, this isn't that useful for royalties (anyone can do the trick described in https://twitter.com/optimizoor/status/1563806550971412480 to "enforce" royalties way more effectively via sheer inconvenience).