### PR TITLE
Add comment on the _mint loop

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -777,8 +777,9 @@ contract ERC721A is IERC721A {
                     startTokenId // `tokenId`.
                 )
 
-                // The `eq` operator ensures that large values of `quantity`
+                // The `iszero(eq(,))` check ensures that large values of `quantity`
                 // that overflows uint256 will make the loop run out of gas.
+                // The compiler will optimize the `iszero` away for performance.
                 for {
                     let tokenId := add(startTokenId, 1)
                 } iszero(eq(tokenId, end)) {

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -777,6 +777,8 @@ contract ERC721A is IERC721A {
                     startTokenId // `tokenId`.
                 )
 
+                // The `eq` operator ensures that large values of `quantity`
+                // that overflows uint256 will make the loop run out of gas.
                 for {
                     let tokenId := add(startTokenId, 1)
                 } iszero(eq(tokenId, end)) {


### PR DESCRIPTION
Added so that in the future, we won't accidentally change `!=` to `<`, which doesn't offer the protection.