### PR TITLE
 create an internal _approve function allowing extensions and EIPs to do approvals without check #426 

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -409,29 +409,14 @@ contract ERC721A is IERC721A {
     // =============================================================
 
     /**
-     * @dev Gives permission to `to` to transfer `tokenId` token to another account.
-     * The approval is cleared when the token is transferred.
-     *
-     * Only a single account can be approved at a time, so approving the
-     * zero address clears previous approvals.
+     * @dev Gives permission to `to` to transfer `tokenId` token to another account. See {ERC721A-_approve}.
      *
      * Requirements:
      *
      * - The caller must own the token or be an approved operator.
-     * - `tokenId` must exist.
-     *
-     * Emits an {Approval} event.
      */
     function approve(address to, uint256 tokenId) public payable virtual override {
-        address owner = ownerOf(tokenId);
-
-        if (_msgSenderERC721A() != owner)
-            if (!isApprovedForAll(owner, _msgSenderERC721A())) {
-                revert ApprovalCallerNotOwnerNorApproved();
-            }
-
-        _tokenApprovals[tokenId].value = to;
-        emit Approval(owner, to, tokenId);
+        _approve(to, tokenId, true);
     }
 
     /**
@@ -891,6 +876,43 @@ contract ERC721A is IERC721A {
      */
     function _safeMint(address to, uint256 quantity) internal virtual {
         _safeMint(to, quantity, '');
+    }
+
+    // =============================================================
+    //                       APPROVAL OPERATIONS
+    // =============================================================
+
+
+    /**
+     * @dev Equivalent to `_approve(to, tokenId, false)`.
+     */
+    function _approve(address to, uint256 tokenId) internal virtual {
+        _approve(to, tokenId, false);
+    }
+
+    /**
+     * @dev Gives permission to `to` to transfer `tokenId` token to another account.
+     * The approval is cleared when the token is transferred.
+     *
+     * Only a single account can be approved at a time, so approving the
+     * zero address clears previous approvals.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
+     *
+     * Emits an {Approval} event.
+     */
+    function _approve(address to, uint256 tokenId, bool approvalCheck) internal virtual {
+        address owner = ownerOf(tokenId);
+
+        if (approvalCheck && _msgSenderERC721A() != owner)
+            if (!isApprovedForAll(owner, _msgSenderERC721A())) {
+                revert ApprovalCallerNotOwnerNorApproved();
+            }
+
+        _tokenApprovals[tokenId].value = to;
+        emit Approval(owner, to, tokenId);
     }
 
     // =============================================================


### PR DESCRIPTION
The current implementation of ERC721A have `_tokenApprovals` private and has all the approval management code in the public facing `approve` function.

This sadly means that there is no way, for a contract extending ERC721A, to internally do approvals without the ownership or isApprovedForAll check.

_There are however some EIPs meant to improve ERC721 and tokens management that are in need of being able to approve internally without those checks._

An example is [EIP-4494](https://eips.ethereum.org/EIPS/eip-4494) that introduces Permits to ERC721, allowing to give approvals to accounts by only signing a message instead of having it done on-chain. Very similar to EIP-2612 for ERC20. 
This EIP could totally change the way we work with marketplaces today, as we would be able to simply sign messages in order to sale items, instead of granting approvalForAll to contracts.

However, EIP-4494 requires the ability to set the approval internally, or at least to bypass the ownership/approvalForAll check, which is right now not possible with the current implementation.

Even if not to accommodate other EIPs and extensions, there can be a lot of reasons for children contracts to be able to do that, similar to the reasons for contracts to be able to `burn` items internally without that check. 

**So, as it was already done with the `_burn()` function, this pull request internalize the content of the `_approve` function with a version that has a 3rd parameter, to indicate if the ownership & isApprovalForAll needs to be checked or not before setting the approval.** 

## Gas Report

### Before

```
·-----------------------------------------------------|---------------------------|-------------|-----------------------------·
|  Methods                                                                                                                    │
····························|·························|·············|·············|·············|···············|··············
|  Contract                 ·  Method                 ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
····························|·························|·············|·············|·············|···············|··············
|  ERC721AMock              ·  approve                ·      50497  ·      52834  ·      50607  ·           26  ·          -  │
····························|·························|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock  ·  approve                ·      52713  ·      55050  ·      52814  ·           26  ·          -  │
····························|·························|·············|·············|·············|···············|··············
|  Deployments                                        ·                                         ·  % of limit   ·             │
······················································|·············|·············|·············|···············|··············
|  ERC721AMock                                        ·          -  ·          -  ·    1374803  ·        4.6 %  ·          -  │
······················································|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock                            ·          -  ·          -  ·    1441224  ·        4.8 %  ·          -  │
······················································|·············|·············|·············|···············|··············
|  ERC721AWithERC2309Mock                             ·    1002042  ·    1002054  ·    1002043  ·        3.3 %  ·          -  │
·-----------------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```

### After

```
·-----------------------------------------------------|---------------------------|-------------|-----------------------------·
|  Methods                                                                                                                    │
····························|·························|·············|·············|·············|···············|··············
|  Contract                 ·  Method                 ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
····························|·························|·············|·············|·············|···············|··············
|  ERC721AMock              ·  approve                ·      50567  ·      52904  ·      50677  ·           26  ·          -  │
····························|·························|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock  ·  approve                ·      52783  ·      55120  ·      52884  ·           26  ·          -  │
····························|·························|·············|·············|·············|···············|··············
|  Deployments                                        ·                                         ·  % of limit   ·             │
······················································|·············|·············|·············|···············|··············
|  ERC721AMock                                        ·          -  ·          -  ·    1379994  ·        4.6 %  ·          -  │
······················································|·············|·············|·············|···············|··············
|  ERC721AStartTokenIdMock                            ·          -  ·          -  ·    1446463  ·        4.8 %  ·          -  │
······················································|·············|·············|·············|···············|··············
|  ERC721AWithERC2309Mock                             ·    1008085  ·    1008097  ·    1008086  ·        3.4 %  ·          -  │
·-----------------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```

**pros**
allows internal approvals without any check of ownership nor weird hack on isApprovedForAll() 

**cons**
slightly more expensive in gas at deployments (~5000gas) and approvals (~70gas)