### PR TITLE
Optimize _packedOwnershipOf 

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -343,40 +343,35 @@ contract ERC721A is IERC721A {
     /**
      * Returns the packed ownership data of `tokenId`.
      */
-     function _packedOwnershipOf(uint256 tokenId) private view returns (uint256) {
-        uint256 curr = tokenId;
-
-        unchecked {
-            if (_startTokenId() <= curr) {
-
-                // load the packed ownership of the current tokenId
-                uint256 packed = _packedOwnerships[curr];
-
-                // If the data exists, and it's not burned, return it and skip tracing 
-                // This is possible because we have already achieved the target condition
-                // This saves 2143 gas on transfers of initialized tokens.
-                if (packed != 0 && packed & _BITMASK_BURNED == 0) return packed;
-
-                // If the tokenId is within index-bounds
-                if (curr < _currentIndex) {
-
-                    // If not burned.
-                    if (packed & _BITMASK_BURNED == 0) {
-                        // Invariant:
-                        // There will always be an initialized ownership slot
-                        // (i.e. `ownership.addr != address(0) && ownership.burned == false`)
-                        // before an unintialized ownership slot
-                        // (i.e. `ownership.addr == address(0) && ownership.burned == false`)
-                        // Hence, `curr` will not underflow.
-                        //
-                        // We can directly compare the packed value.
-                        // If the address is zero, packed will be zero.
-                        while (packed == 0) {
-                            packed = _packedOwnerships[--curr];
+    function _packedOwnershipOf(uint256 tokenId) private view returns (uint256 packed) {    
+        if (_startTokenId() <= tokenId) {
+            packed = _packedOwnerships[tokenId];
+            // If not burned.
+            if (packed & _BITMASK_BURNED == 0) {
+                // If the data at the starting slot does not exist, start the scan.
+                if (packed == 0) {
+                    if (tokenId >= _currentIndex) revert OwnerQueryForNonexistentToken();
+                    // Invariant:
+                    // There will always be an initialized ownership slot
+                    // (i.e. `ownership.addr != address(0) && ownership.burned == false`)
+                    // before an unintialized ownership slot
+                    // (i.e. `ownership.addr == address(0) && ownership.burned == false`)
+                    // Hence, `tokenId` will not underflow.
+                    //
+                    // We can directly compare the packed value.
+                    // If the address is zero, packed will be zero.
+                    for (;;) {
+                        unchecked {
+                            packed = _packedOwnerships[--tokenId];
                         }
+                        if (packed == 0) continue;
                         return packed;
                     }
                 }
+                // Otherwise, the data exists and is not burned. We can skip the scan.
+                // This is possible because we have already achieved the target condition.
+                // This saves 2143 gas on transfers of initialized tokens.
+                return packed;
             }
         }
         revert OwnerQueryForNonexistentToken();


### PR DESCRIPTION
Also fixes the extra space.

**Before:**
```
·----------------------------------------------|---------------------------|-------------|-----------------------------·
|             Solc version: 0.8.11             ·  Optimizer enabled: true  ·  Runs: 800  ·  Block limit: 30000000 gas  │
···············································|···························|·············|······························
|  Methods                                                                                                             │
···························|···················|·············|·············|·············|···············|··············
|  Contract                ·  Method           ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
···························|···················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  mintOne          ·      56165  ·      90365  ·      59585  ·           10  ·          -  │
···························|···················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  mintTen          ·      73540  ·     107740  ·      97480  ·           10  ·          -  │
···························|···················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  safeMintOne      ·      58915  ·      93115  ·      76015  ·            2  ·          -  │
···························|···················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  safeMintTen      ·      76291  ·     110491  ·      93391  ·            2  ·          -  │
···························|···················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  transferFrom     ·      42208  ·      86059  ·      53171  ·            4  ·          -  │
···························|···················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  transferTenAsc   ·          -  ·          -  ·     296259  ·            1  ·          -  │
···························|···················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  transferTenAvg   ·          -  ·          -  ·     297714  ·            1  ·          -  │
···························|···················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  transferTenDesc  ·          -  ·          -  ·     304291  ·            1  ·          -  │
···························|···················|·············|·············|·············|···············|··············
|  ERC721AWithERC2309Mock  ·  mintOneERC2309   ·      56420  ·      90620  ·      73520  ·            3  ·          -  │
···························|···················|·············|·············|·············|···············|··············
|  ERC721AWithERC2309Mock  ·  mintTenERC2309   ·      56397  ·      90597  ·      73497  ·            3  ·          -  │
···························|···················|·············|·············|·············|···············|··············
|  Deployments                                 ·                                         ·  % of limit   ·             │
···············································|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock                      ·          -  ·          -  ·    1113023  ·        3.7 %  ·          -  │
···············································|·············|·············|·············|···············|··············
|  ERC721AWithERC2309Mock                      ·          -  ·          -  ·     947715  ·        3.2 %  ·          -  │
·----------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```

**After:**
```
·----------------------------------------------|---------------------------|-------------|-----------------------------·
|             Solc version: 0.8.11             ·  Optimizer enabled: true  ·  Runs: 800  ·  Block limit: 30000000 gas  │
···············································|···························|·············|······························
|  Methods                                                                                                             │
···························|···················|·············|·············|·············|···············|··············
|  Contract                ·  Method           ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
···························|···················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  mintOne          ·      56165  ·      90365  ·      59585  ·           10  ·          -  │
···························|···················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  mintTen          ·      73540  ·     107740  ·      97480  ·           10  ·          -  │
···························|···················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  safeMintOne      ·      58915  ·      93115  ·      76015  ·            2  ·          -  │
···························|···················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  safeMintTen      ·      76291  ·     110491  ·      93391  ·            2  ·          -  │
···························|···················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  transferFrom     ·      42178  ·      85989  ·      53131  ·            4  ·          -  │
···························|···················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  transferTenAsc   ·          -  ·          -  ·     295959  ·            1  ·          -  │
···························|···················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  transferTenAvg   ·          -  ·          -  ·     297254  ·            1  ·          -  │
···························|···················|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock  ·  transferTenDesc  ·          -  ·          -  ·     303631  ·            1  ·          -  │
···························|···················|·············|·············|·············|···············|··············
|  ERC721AWithERC2309Mock  ·  mintOneERC2309   ·      56420  ·      90620  ·      73520  ·            3  ·          -  │
···························|···················|·············|·············|·············|···············|··············
|  ERC721AWithERC2309Mock  ·  mintTenERC2309   ·      56397  ·      90597  ·      73497  ·            3  ·          -  │
···························|···················|·············|·············|·············|···············|··············
|  Deployments                                 ·                                         ·  % of limit   ·             │
···············································|·············|·············|·············|···············|··············
|  ERC721AGasReporterMock                      ·          -  ·          -  ·    1111763  ·        3.7 %  ·          -  │
···············································|·············|·············|·············|···············|··············
|  ERC721AWithERC2309Mock                      ·          -  ·          -  ·     946425  ·        3.2 %  ·          -  │
·----------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```