### PR TITLE
gas optimizations ✨

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -815,11 +815,11 @@ contract ERC721A is IERC721A {
      * Emits a {ConsecutiveTransfer} event.
      */
     function _mintERC2309(address to, uint256 quantity) internal virtual {
-        uint256 startTokenId = _currentIndex;
         if (to == address(0)) _revert(0x2e076300); // MintToZeroAddress() hash
         if (quantity == 0) _revert(0xb562e8dd); // MintZeroQuantity() hash
         if (quantity > _MAX_MINT_ERC2309_QUANTITY_LIMIT) _revert(0x3db1f9af); // MintERC2309QuantityExceedsLimit() hash
 
+        uint256 startTokenId = _currentIndex;
         _beforeTokenTransfers(address(0), to, startTokenId, quantity);
 
         // Overflows are unrealistic due to the above check for `quantity` to be below the limit.

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -1082,7 +1082,7 @@ contract ERC721A is IERC721A {
 
         // Overflow not possible, as _burnCounter cannot be exceed _currentIndex times.
         unchecked {
-            _burnCounter++;
+            ++_burnCounter;
         }
     }
 

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -90,6 +90,21 @@ contract ERC721A is IERC721A {
     bytes32 private constant _TRANSFER_EVENT_SIGNATURE =
         0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef;
 
+    // The `Approval` event signature is given by:
+    // `keccak256(bytes("Approval(address,address,uint256)"))`.
+    bytes32 private constant _APPROVAL_EVENT_SIGNATURE =
+        0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925;
+
+    // The `ApprovalForAll` event signature is given by:
+    // `keccak256(bytes("ApprovalForAll(address,address,bool)"))`.
+    bytes32 private constant _APPROVAL_FOR_ALL_EVENT_SIGNATURE =
+        0x17307eab39ab6107e8899845ad3d59bd9653f200f220920489ca2b5937696c31;
+
+    // The `Approval` event signature is given by:
+    // `keccak256(bytes("ConsecutiveTransfer(uint256,uint256,address,address)"))`.
+    bytes32 private constant _CONSECUTIVE_TRANSFER_EVENT_SIGNATURE =
+        0xdeaa91b6123d068f5821d0fb0678463d1a8a6079fe8af5de3ce5e896dcf9133d;
+
     // =============================================================
     //                            STORAGE
     // =============================================================

--- a/contracts/extensions/ERC4907A.sol
+++ b/contracts/extensions/ERC4907A.sol
@@ -44,8 +44,8 @@ abstract contract ERC4907A is ERC721A, IERC4907A {
             if (!isApprovedForAll(owner, _msgSenderERC721A()))
                 if (getApproved(tokenId) != _msgSenderERC721A()) {
                     assembly {
-                        mstore(0, 0x4f1dd8e8) // SetUserCallerNotOwnerNorApproved() hash
-                        revert(0x1c, 4)
+                        mstore(0x00, 0x4f1dd8e8) // SetUserCallerNotOwnerNorApproved() hash
+                        revert(0x1c, 0x04)
                     }
                 }
 

--- a/contracts/extensions/ERC4907A.sol
+++ b/contracts/extensions/ERC4907A.sol
@@ -43,9 +43,10 @@ abstract contract ERC4907A is ERC721A, IERC4907A {
         if (_msgSenderERC721A() != owner)
             if (!isApprovedForAll(owner, _msgSenderERC721A()))
                 if (getApproved(tokenId) != _msgSenderERC721A()) {
+                    bytes4 errorHash = 0x4f1dd8e8; // SetUserCallerNotOwnerNorApproved() hash
                     assembly {
-                        mstore(0, 0x4f1dd8e8) // SetUserCallerNotOwnerNorApproved() hash
-                        revert(0x1C, 4)
+                        mstore(0, errorHash)
+                        revert(0, 4)
                     }
                 }
 

--- a/contracts/extensions/ERC4907A.sol
+++ b/contracts/extensions/ERC4907A.sol
@@ -42,7 +42,12 @@ abstract contract ERC4907A is ERC721A, IERC4907A {
         address owner = ownerOf(tokenId);
         if (_msgSenderERC721A() != owner)
             if (!isApprovedForAll(owner, _msgSenderERC721A()))
-                if (getApproved(tokenId) != _msgSenderERC721A()) revert SetUserCallerNotOwnerNorApproved();
+                if (getApproved(tokenId) != _msgSenderERC721A()) {
+                    assembly {
+                        mstore(0, 0x4f1dd8e8) // SetUserCallerNotOwnerNorApproved() hash
+                        revert(0x1C, 4)
+                    }
+                }
 
         _packedUserInfo[tokenId] = (uint256(expires) << _BITPOS_EXPIRES) | uint256(uint160(user));
 

--- a/contracts/extensions/ERC4907A.sol
+++ b/contracts/extensions/ERC4907A.sol
@@ -43,10 +43,9 @@ abstract contract ERC4907A is ERC721A, IERC4907A {
         if (_msgSenderERC721A() != owner)
             if (!isApprovedForAll(owner, _msgSenderERC721A()))
                 if (getApproved(tokenId) != _msgSenderERC721A()) {
-                    bytes4 errorHash = 0x4f1dd8e8; // SetUserCallerNotOwnerNorApproved() hash
                     assembly {
-                        mstore(0, errorHash)
-                        revert(0, 4)
+                        mstore(0, 0x4f1dd8e8) // SetUserCallerNotOwnerNorApproved() hash
+                        revert(0x1c, 4)
                     }
                 }
 

--- a/contracts/extensions/ERC4907A.sol
+++ b/contracts/extensions/ERC4907A.sol
@@ -42,12 +42,7 @@ abstract contract ERC4907A is ERC721A, IERC4907A {
         address owner = ownerOf(tokenId);
         if (_msgSenderERC721A() != owner)
             if (!isApprovedForAll(owner, _msgSenderERC721A()))
-                if (getApproved(tokenId) != _msgSenderERC721A()) {
-                    assembly {
-                        mstore(0x00, 0x4f1dd8e8) // SetUserCallerNotOwnerNorApproved() hash
-                        revert(0x1c, 0x04)
-                    }
-                }
+                if (getApproved(tokenId) != _msgSenderERC721A()) _revert(SetUserCallerNotOwnerNorApproved.selector);
 
         _packedUserInfo[tokenId] = (uint256(expires) << _BITPOS_EXPIRES) | uint256(uint160(user));
 

--- a/contracts/extensions/ERC721AQueryable.sol
+++ b/contracts/extensions/ERC721AQueryable.sol
@@ -89,9 +89,10 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
     ) external view virtual override returns (uint256[] memory) {
         unchecked {
             if (start >= stop) {
+                bytes4 errorHash = 0x32c1995a; // InvalidQueryRange() hash
                 assembly {
-                    mstore(0, 0x32c1995a) // InvalidQueryRange() hash
-                    revert(0x1C, 4)
+                    mstore(0, errorHash)
+                    revert(0, 4)
                 }
             }
             uint256 tokenIdsIdx;

--- a/contracts/extensions/ERC721AQueryable.sol
+++ b/contracts/extensions/ERC721AQueryable.sol
@@ -88,7 +88,12 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
         uint256 stop
     ) external view virtual override returns (uint256[] memory) {
         unchecked {
-            if (start >= stop) revert InvalidQueryRange();
+            if (start >= stop) {
+                assembly {
+                    mstore(0, 0x32c1995a) // InvalidQueryRange() hash
+                    revert(0x1C, 4)
+                }
+            }
             uint256 tokenIdsIdx;
             uint256 stopLimit = _nextTokenId();
             // Set `start = max(start, _startTokenId())`.

--- a/contracts/extensions/ERC721AQueryable.sol
+++ b/contracts/extensions/ERC721AQueryable.sol
@@ -88,12 +88,7 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
         uint256 stop
     ) external view virtual override returns (uint256[] memory) {
         unchecked {
-            if (start >= stop) {
-                assembly {
-                    mstore(0x00, 0x32c1995a) // InvalidQueryRange() hash
-                    revert(0x1c, 0x04)
-                }
-            }
+            if (start >= stop) _revert(InvalidQueryRange.selector);
             uint256 tokenIdsIdx;
             uint256 stopLimit = _nextTokenId();
             // Set `start = max(start, _startTokenId())`.

--- a/contracts/extensions/ERC721AQueryable.sol
+++ b/contracts/extensions/ERC721AQueryable.sol
@@ -90,8 +90,8 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
         unchecked {
             if (start >= stop) {
                 assembly {
-                    mstore(0, 0x32c1995a) // InvalidQueryRange() hash
-                    revert(0x1c, 4)
+                    mstore(0x00, 0x32c1995a) // InvalidQueryRange() hash
+                    revert(0x1c, 0x04)
                 }
             }
             uint256 tokenIdsIdx;

--- a/contracts/extensions/ERC721AQueryable.sol
+++ b/contracts/extensions/ERC721AQueryable.sol
@@ -89,10 +89,9 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
     ) external view virtual override returns (uint256[] memory) {
         unchecked {
             if (start >= stop) {
-                bytes4 errorHash = 0x32c1995a; // InvalidQueryRange() hash
                 assembly {
-                    mstore(0, errorHash)
-                    revert(0, 4)
+                    mstore(0, 0x32c1995a) // InvalidQueryRange() hash
+                    revert(0x1c, 4)
                 }
             }
             uint256 tokenIdsIdx;


### PR DESCRIPTION
a more efficient approach to save on runtime reverts (30 gas) + deployment cost (7500 gas per revert message) is to revert using assembly and explicitly assign bytes4 error message hash, Win-Win. Also, there are cases where SLOAD is being performed before a revert, which is better to be assigned after, so on reverts doesn't go to waste. a contract was deployed after those changes and the deployment  gas cost saving is 82053.

--Code-- 