### PR TITLE
add yarn install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ npm install --save-dev erc721a
 
 ```
 
+Or, if you prefer to use yarn:
+
+```sh
+
+yarn add erc721a
+
+```
+
 <!-- USAGE EXAMPLES -->
 
 ## Usage


### PR DESCRIPTION
explicitly provided the yarn add install option for js/ts projects like hardhat etc, as a nod to the growing popularity of yarn and its advantages in modernity over npm.

(helps save some newer devs from issues with conflicting packages)