### PR TITLE
Non-sequential minting (a.k.a spot-minting) support

### DIFF
--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -134,7 +134,7 @@ contract ERC721A is IERC721A {
     mapping(address => mapping(address => bool)) private _operatorApprovals;
 
     // The amount of tokens minted above `_sequentialUpTo()`.
-    // We call these "spot-minted" tokens.
+    // We call these spot mints.
     uint256 private _spotMinted;
 
     // =============================================================
@@ -155,17 +155,23 @@ contract ERC721A is IERC721A {
     // =============================================================
 
     /**
-     * @dev Returns the starting token ID.
-     * To change the starting token ID, please override this function.
+     * @dev Returns the starting token ID for sequential mints.
+     *
+     * Override this function to change the starting token ID for sequential mints.
+     *
+     * Note: The value returned must never change after any tokens have been minted.
      */
     function _startTokenId() internal view virtual returns (uint256) {
         return 0;
     }
 
     /**
-     * @dev Returns the maximum token ID (inclusive) for sequential minting.
-     * To enable spot (non-sequential) minting of tokens above `_sequentialUpTo()`,
-     * override this function to larger than `_startTokenId()`, but smaller than 2**256 - 1.
+     * @dev Returns the maximum token ID (inclusive) for sequential mints.
+     *
+     * Override this function to return a value less than 2**256 - 1,
+     * but greater than `_startTokenId()`, to enable spot (non-sequential) mints.
+     *
+     * Note: The value returned must never change after any tokens have been minted.
      */
     function _sequentialUpTo() internal view virtual returns (uint256) {
         return type(uint256).max;
@@ -829,7 +835,7 @@ contract ERC721A is IERC721A {
             uint256 tokenId = startTokenId;
 
             if (_sequentialUpTo() != type(uint256).max)
-                if (end > _sequentialUpTo()) _revert(SequentialMintsExceedLimit.selector);
+                if (end > _sequentialUpTo()) _revert(SequentialMintExceedLimit.selector);
 
             do {
                 assembly {
@@ -905,7 +911,7 @@ contract ERC721A is IERC721A {
             _currentIndex = startTokenId + quantity;
 
             if (_sequentialUpTo() != type(uint256).max)
-                if (startTokenId + quantity > _sequentialUpTo()) _revert(SequentialMintsExceedLimit.selector);
+                if (startTokenId + quantity > _sequentialUpTo()) _revert(SequentialMintExceedLimit.selector);
         }
         _afterTokenTransfers(address(0), to, startTokenId, quantity);
     }

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -515,8 +515,8 @@ contract ERC721A is IERC721A {
      */
     function _exists(uint256 tokenId) internal view virtual returns (bool result) {
         if (_startTokenId() <= tokenId) {
-            if (_sequentialUpTo() != type(uint256).max && tokenId > _sequentialUpTo())
-                return _packedOwnershipExists(_packedOwnerships[tokenId]);
+            if (_sequentialUpTo() != type(uint256).max)
+                if (tokenId > _sequentialUpTo()) return _packedOwnershipExists(_packedOwnerships[tokenId]);
 
             if (tokenId < _currentIndex) {
                 uint256 packed;

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -145,7 +145,7 @@ contract ERC721A is IERC721A {
         _name = name_;
         _symbol = symbol_;
         _currentIndex = _startTokenId();
-        // Construction-time check if spot minting is enabled.
+
         if (_sequentialUpTo() != type(uint256).max)
             if (_sequentialUpTo() <= _startTokenId()) revert SequentialUpToTooSmall();
     }
@@ -188,7 +188,6 @@ contract ERC721A is IERC721A {
         // more than `_currentIndex - _startTokenId()` times.
         unchecked {
             result = _currentIndex - _burnCounter - _startTokenId();
-            // If spot minting is enabled, add `_spotMinted`.
             if (_sequentialUpTo() != type(uint256).max) result += _spotMinted;
         }
     }
@@ -201,7 +200,6 @@ contract ERC721A is IERC721A {
         // and it is initialized to `_startTokenId()`.
         unchecked {
             result = _currentIndex - _startTokenId();
-            // If spot minting is enabled, add `_spotMinted`.
             if (_sequentialUpTo() != type(uint256).max) result += _spotMinted;
         }
     }

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -515,9 +515,9 @@ contract ERC721A is IERC721A {
      */
     function _exists(uint256 tokenId) internal view virtual returns (bool result) {
         if (_startTokenId() <= tokenId) {
-            if (_sequentialUpTo() != type(uint256).max) {
-                if (tokenId > _sequentialUpTo()) return _packedOwnershipExists(_packedOwnerships[tokenId]);
-            }
+            if (_sequentialUpTo() != type(uint256).max && tokenId > _sequentialUpTo())
+                return _packedOwnershipExists(_packedOwnerships[tokenId]);
+
             if (tokenId < _currentIndex) {
                 uint256 packed;
                 while ((packed = _packedOwnerships[tokenId]) == 0) --tokenId;

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -146,7 +146,7 @@ contract ERC721A is IERC721A {
         _symbol = symbol_;
         _currentIndex = _startTokenId();
 
-        if (_sequentialUpTo() <= _startTokenId()) revert SequentialUpToTooSmall();
+        if (_sequentialUpTo() <= _startTokenId()) _revert(SequentialUpToTooSmall.selector);
     }
 
     // =============================================================

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -146,8 +146,7 @@ contract ERC721A is IERC721A {
         _symbol = symbol_;
         _currentIndex = _startTokenId();
 
-        if (_sequentialUpTo() != type(uint256).max)
-            if (_sequentialUpTo() <= _startTokenId()) revert SequentialUpToTooSmall();
+        if (_sequentialUpTo() <= _startTokenId()) revert SequentialUpToTooSmall();
     }
 
     // =============================================================

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -522,7 +522,8 @@ contract ERC721A is IERC721A {
             // Workflow if spot-minting is enabled.
             if (_sequentialUpTo() != type(uint256).max) {
                 // If the `tokenId` is above the sequential range.
-                if (tokenId > _sequentialUpTo()) return _packedOwnershipExists(_packedOwnerships[tokenId]);
+                if (tokenId > _sequentialUpTo()) 
+                    return _packedOwnershipExists(_packedOwnerships[tokenId]);
             }
             if (tokenId < _currentIndex) {
                 uint256 packed;
@@ -834,8 +835,9 @@ contract ERC721A is IERC721A {
             uint256 end = startTokenId + quantity;
             uint256 tokenId = startTokenId;
 
-            if (_sequentialUpTo() != type(uint256).max)
-                if (end > _sequentialUpTo()) _revert(SequentialMintsExceedLimit.selector);
+            if (_sequentialUpTo() != type(uint256).max) 
+                if (end > _sequentialUpTo())
+                    _revert(SequentialMintsExceedLimit.selector);
 
             do {
                 assembly {
@@ -910,8 +912,9 @@ contract ERC721A is IERC721A {
 
             _currentIndex = startTokenId + quantity;
 
-            if (_sequentialUpTo() != type(uint256).max)
-                if (startTokenId + quantity > _sequentialUpTo()) _revert(SequentialMintsExceedLimit.selector);
+            if (_sequentialUpTo() != type(uint256).max) 
+                if (startTokenId + quantity > _sequentialUpTo()) 
+                    _revert(SequentialMintsExceedLimit.selector);
         }
         _afterTokenTransfers(address(0), to, startTokenId, quantity);
     }

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -134,7 +134,7 @@ contract ERC721A is IERC721A {
     mapping(address => mapping(address => bool)) private _operatorApprovals;
 
     // The amount of tokens minted above `_sequentialUpTo()`.
-    // We call these spot mints.
+    // We call these spot mints (i.e. non-sequential mints).
     uint256 private _spotMinted;
 
     // =============================================================

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -533,10 +533,11 @@ contract ERC721A is IERC721A {
     }
 
     /**
-     * @dev Returns whether the the packed ownership exists.
+     * @dev Returns whether `packed` represents a token that exists.
      */
     function _packedOwnershipExists(uint256 packed) private pure returns (bool result) {
         assembly {
+            // The following is equivalent to `owner != address(0) && burned == false`.
             result := gt(and(packed, _BITMASK_ADDRESS), and(packed, _BITMASK_BURNED))
         }
     }

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -28,6 +28,9 @@ interface ERC721A__IERC721Receiver {
  * Token IDs are minted in sequential order (e.g. 0, 1, 2, 3, ...)
  * starting from `_startTokenId()`.
  *
+ * The `_sequentialUpTo()` function can be overriden to enable spot mints
+ * (i.e. non-consecutive mints) for `tokenId`s greater than `_sequentialUpTo()`.
+ *
  * Assumptions:
  *
  * - An owner cannot have more than 2**64 - 1 (max value of uint64) of supply.
@@ -189,8 +192,8 @@ contract ERC721A is IERC721A {
      * To get the total number of tokens minted, please see {_totalMinted}.
      */
     function totalSupply() public view virtual override returns (uint256 result) {
-        // Counter underflow is impossible as _burnCounter cannot be incremented
-        // more than `_currentIndex - _startTokenId()` times.
+        // Counter underflow is impossible as `_burnCounter` cannot be incremented
+        // more than `_currentIndex + _spotMinted - _startTokenId()` times.
         unchecked {
             result = _currentIndex - _burnCounter - _startTokenId();
             if (_sequentialUpTo() != type(uint256).max) result += _spotMinted;

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -386,11 +386,9 @@ contract ERC721A is IERC721A {
         if (_startTokenId() <= tokenId) {
             packed = _packedOwnerships[tokenId];
 
-            if (_sequentialUpTo() != type(uint256).max) {
-                if (tokenId > _sequentialUpTo()) {
-                    if (_packedOwnershipExists(packed)) return packed;
-                    _revert(OwnerQueryForNonexistentToken.selector);
-                }
+            if (tokenId > _sequentialUpTo()) {
+                if (_packedOwnershipExists(packed)) return packed;
+                _revert(OwnerQueryForNonexistentToken.selector);
             }
 
             // If the data at the starting slot does not exist, start the scan.
@@ -521,8 +519,7 @@ contract ERC721A is IERC721A {
      */
     function _exists(uint256 tokenId) internal view virtual returns (bool result) {
         if (_startTokenId() <= tokenId) {
-            if (_sequentialUpTo() != type(uint256).max)
-                if (tokenId > _sequentialUpTo()) return _packedOwnershipExists(_packedOwnerships[tokenId]);
+            if (tokenId > _sequentialUpTo()) return _packedOwnershipExists(_packedOwnerships[tokenId]);
 
             if (tokenId < _currentIndex) {
                 uint256 packed;
@@ -835,8 +832,7 @@ contract ERC721A is IERC721A {
             uint256 end = startTokenId + quantity;
             uint256 tokenId = startTokenId;
 
-            if (_sequentialUpTo() != type(uint256).max)
-                if (end > _sequentialUpTo()) _revert(SequentialMintExceedLimit.selector);
+            if (end > _sequentialUpTo()) _revert(SequentialMintExceedLimit.selector);
 
             do {
                 assembly {
@@ -911,8 +907,7 @@ contract ERC721A is IERC721A {
 
             _currentIndex = startTokenId + quantity;
 
-            if (_sequentialUpTo() != type(uint256).max)
-                if (startTokenId + quantity > _sequentialUpTo()) _revert(SequentialMintExceedLimit.selector);
+            if (startTokenId + quantity > _sequentialUpTo()) _revert(SequentialMintExceedLimit.selector);
         }
         _afterTokenTransfers(address(0), to, startTokenId, quantity);
     }

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -963,6 +963,8 @@ contract ERC721A is IERC721A {
      * - `tokenId` must be greater than `_sequentialUpTo()`.
      * - `tokenId` must not exist.
      *
+     * If the token at `tokenId` has been previously burned, its `extraData` will be cleared.
+     *
      * Emits a {Transfer} event for each mint.
      */
     function _mintSpot(address to, uint256 tokenId) internal virtual {

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -517,10 +517,8 @@ contract ERC721A is IERC721A {
      */
     function _exists(uint256 tokenId) internal view virtual returns (bool result) {
         if (_startTokenId() <= tokenId) {
-            
             if (_sequentialUpTo() != type(uint256).max) {
-                if (tokenId > _sequentialUpTo()) 
-                    return _packedOwnershipExists(_packedOwnerships[tokenId]);
+                if (tokenId > _sequentialUpTo()) return _packedOwnershipExists(_packedOwnerships[tokenId]);
             }
             if (tokenId < _currentIndex) {
                 uint256 packed;
@@ -535,7 +533,7 @@ contract ERC721A is IERC721A {
      */
     function _packedOwnershipExists(uint256 packed) private pure returns (bool result) {
         assembly {
-            result := iszero(or(iszero(packed), and(packed, _BITMASK_BURNED)))
+            result := gt(and(packed, _BITMASK_ADDRESS), and(packed, _BITMASK_BURNED))
         }
     }
 
@@ -832,9 +830,8 @@ contract ERC721A is IERC721A {
             uint256 end = startTokenId + quantity;
             uint256 tokenId = startTokenId;
 
-            if (_sequentialUpTo() != type(uint256).max) 
-                if (end > _sequentialUpTo())
-                    _revert(SequentialMintsExceedLimit.selector);
+            if (_sequentialUpTo() != type(uint256).max)
+                if (end > _sequentialUpTo()) _revert(SequentialMintsExceedLimit.selector);
 
             do {
                 assembly {
@@ -909,9 +906,8 @@ contract ERC721A is IERC721A {
 
             _currentIndex = startTokenId + quantity;
 
-            if (_sequentialUpTo() != type(uint256).max) 
-                if (startTokenId + quantity > _sequentialUpTo()) 
-                    _revert(SequentialMintsExceedLimit.selector);
+            if (_sequentialUpTo() != type(uint256).max)
+                if (startTokenId + quantity > _sequentialUpTo()) _revert(SequentialMintsExceedLimit.selector);
         }
         _afterTokenTransfers(address(0), to, startTokenId, quantity);
     }

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -940,7 +940,7 @@ contract ERC721A is IERC721A {
                         _revert(TransferToNonERC721ReceiverImplementer.selector);
                     }
                 } while (index < end);
-                // Reentrancy protection, scoped to `_mint`.
+                // Reentrancy protection, scoped to `_safeMint`.
                 if (_currentIndex != end) revert();
             }
         }
@@ -1041,7 +1041,7 @@ contract ERC721A is IERC721A {
                 if (!_checkContractOnERC721Received(address(0), to, tokenId, _data)) {
                     _revert(TransferToNonERC721ReceiverImplementer.selector);
                 }
-                // Reentrancy protection, scoped to `_mintSpot`.
+                // Reentrancy protection, scoped to `_safeMintSpot`.
                 if (_spotMinted != currentSpotMinted) revert();
             }
         }

--- a/contracts/ERC721A.sol
+++ b/contracts/ERC721A.sol
@@ -380,17 +380,15 @@ contract ERC721A is IERC721A {
      */
     function _packedOwnershipOf(uint256 tokenId) private view returns (uint256 packed) {
         if (_startTokenId() <= tokenId) {
-            // Workflow if spot-minting is enabled.
+            packed = _packedOwnerships[tokenId];
+
             if (_sequentialUpTo() != type(uint256).max) {
-                // If the `tokenId` is above the sequential range.
                 if (tokenId > _sequentialUpTo()) {
-                    packed = _packedOwnerships[tokenId];
-                    if (packed & _BITMASK_BURNED == 0) _revert(OwnerQueryForNonexistentToken.selector);
-                    return packed;
+                    if (_packedOwnershipExists(packed)) return packed;
+                    _revert(OwnerQueryForNonexistentToken.selector);
                 }
             }
 
-            packed = _packedOwnerships[tokenId];
             // If the data at the starting slot does not exist, start the scan.
             if (packed == 0) {
                 if (tokenId >= _currentIndex) _revert(OwnerQueryForNonexistentToken.selector);
@@ -519,9 +517,8 @@ contract ERC721A is IERC721A {
      */
     function _exists(uint256 tokenId) internal view virtual returns (bool result) {
         if (_startTokenId() <= tokenId) {
-            // Workflow if spot-minting is enabled.
+            
             if (_sequentialUpTo() != type(uint256).max) {
-                // If the `tokenId` is above the sequential range.
                 if (tokenId > _sequentialUpTo()) 
                     return _packedOwnershipExists(_packedOwnerships[tokenId]);
             }

--- a/contracts/IERC721A.sol
+++ b/contracts/IERC721A.sol
@@ -74,6 +74,31 @@ interface IERC721A {
      */
     error OwnershipNotInitializedForExtraData();
 
+    /**
+     * `_sequentialUpTo()` must be greater than `_startTokenId()`.
+     */
+    error SequentialUpToTooSmall();
+
+    /**
+     * The `tokenId` of a sequential mint exceeds `_sequentialUpTo()`.
+     */
+    error SequentialMintsExceedLimit();
+
+    /**
+     * Spot minting requires a `tokenId` greater than `_sequentialUpTo()`.
+     */
+    error SpotMintTokenIdTooSmall();
+
+    /**
+     * Cannot mint over a token that already exists.
+     */
+    error TokenAlreadyExists();
+
+    /**
+     * The feature is not compatible with spot mints.
+     */
+    error NotCompatibleWithSpotMints();
+
     // =============================================================
     //                            STRUCTS
     // =============================================================

--- a/contracts/IERC721A.sol
+++ b/contracts/IERC721A.sol
@@ -82,7 +82,7 @@ interface IERC721A {
     /**
      * The `tokenId` of a sequential mint exceeds `_sequentialUpTo()`.
      */
-    error SequentialMintsExceedLimit();
+    error SequentialMintExceedLimit();
 
     /**
      * Spot minting requires a `tokenId` greater than `_sequentialUpTo()`.

--- a/contracts/IERC721A.sol
+++ b/contracts/IERC721A.sol
@@ -82,7 +82,7 @@ interface IERC721A {
     /**
      * The `tokenId` of a sequential mint exceeds `_sequentialUpTo()`.
      */
-    error SequentialMintExceedLimit();
+    error SequentialMintExceedsLimit();
 
     /**
      * Spot minting requires a `tokenId` greater than `_sequentialUpTo()`.

--- a/contracts/extensions/ERC721AQueryable.sol
+++ b/contracts/extensions/ERC721AQueryable.sol
@@ -130,6 +130,7 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
      * an out-of-gas error (10K collections should be fine).
      */
     function tokensOfOwner(address owner) external view virtual override returns (uint256[] memory) {
+        // If spot mints are enabled, full-range scan is disabled.
         if (_sequentialUpTo() != type(uint256).max) _revert(NotCompatibleWithSpotMints.selector);
         uint256 start = _startTokenId();
         uint256 stop = _nextTokenId();

--- a/contracts/extensions/ERC721AQueryable.sol
+++ b/contracts/extensions/ERC721AQueryable.sol
@@ -46,6 +46,12 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
     {
         unchecked {
             if (tokenId >= _startTokenId()) {
+                // Workflow if spot-minting is enabled.
+                if (_sequentialUpTo() != type(uint256).max) {
+                    // If the `tokenId` is above the sequential range.
+                    if (tokenId > _sequentialUpTo()) 
+                        return _ownershipAt(tokenId);
+                }
                 if (tokenId < _nextTokenId()) {
                     // If the `tokenId` is within bounds,
                     // scan backwards for the initialized ownership slot.
@@ -125,6 +131,7 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
      * an out-of-gas error (10K collections should be fine).
      */
     function tokensOfOwner(address owner) external view virtual override returns (uint256[] memory) {
+        if (_sequentialUpTo() != type(uint256).max) _revert(NotCompatibleWithSpotMints.selector);
         uint256 start = _startTokenId();
         uint256 stop = _nextTokenId();
         uint256[] memory tokenIds;

--- a/contracts/extensions/ERC721AQueryable.sol
+++ b/contracts/extensions/ERC721AQueryable.sol
@@ -154,18 +154,14 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
                 start = _startTokenId();
             }
             uint256 nextTokenId = _nextTokenId();
-            uint256 stopLimit = _sequentialUpTo() != type(uint256).max ? type(uint256).max : nextTokenId;
+            uint256 stopLimit = _sequentialUpTo() != type(uint256).max ? stop : nextTokenId;
             // Set `stop = min(stop, stopLimit)`.
             if (stop >= stopLimit) {
                 stop = stopLimit;
             }
             uint256[] memory tokenIds;
-            uint256 tokenIdsMaxLength = balanceOf(owner);
-            bool startLtStop = start < stop;
-            assembly {
-                // Set `tokenIdsMaxLength` to zero if `start` is less than `stop`.
-                tokenIdsMaxLength := mul(tokenIdsMaxLength, startLtStop)
-            }
+            uint256 tokenIdsMaxLength;
+            if (start < stop) tokenIdsMaxLength = balanceOf(owner);
             if (tokenIdsMaxLength != 0) {
                 // Set `tokenIdsMaxLength = min(balanceOf(owner), stop - start)`,
                 // to cater for cases where `balanceOf(owner)` is too big.

--- a/contracts/extensions/ERC721AQueryable.sol
+++ b/contracts/extensions/ERC721AQueryable.sol
@@ -193,7 +193,9 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
                 // as the array will at least contain one element.
                 do {
                     if (_sequentialUpTo() != type(uint256).max) {
+                        // Skip the remaining unused sequential slots.
                         if (start == nextTokenId) start = _sequentialUpTo() + 1;
+                        // Reset `currOwnershipAddr`, as each spot-minted token is a batch of one.
                         if (start > _sequentialUpTo()) currOwnershipAddr = address(0);
                     }
                     ownership = _ownershipAt(start);

--- a/contracts/extensions/ERC721AQueryable.sol
+++ b/contracts/extensions/ERC721AQueryable.sol
@@ -46,11 +46,8 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
     {
         unchecked {
             if (tokenId >= _startTokenId()) {
-                // Workflow if spot-minting is enabled.
-                if (_sequentialUpTo() != type(uint256).max) {
-                    // If the `tokenId` is above the sequential range.
-                    if (tokenId > _sequentialUpTo()) return _ownershipAt(tokenId);
-                }
+                if (tokenId > _sequentialUpTo()) return _ownershipAt(tokenId);
+
                 if (tokenId < _nextTokenId()) {
                     // If the `tokenId` is within bounds,
                     // scan backwards for the initialized ownership slot.

--- a/contracts/extensions/ERC721AQueryable.sol
+++ b/contracts/extensions/ERC721AQueryable.sol
@@ -49,8 +49,7 @@ abstract contract ERC721AQueryable is ERC721A, IERC721AQueryable {
                 // Workflow if spot-minting is enabled.
                 if (_sequentialUpTo() != type(uint256).max) {
                     // If the `tokenId` is above the sequential range.
-                    if (tokenId > _sequentialUpTo()) 
-                        return _ownershipAt(tokenId);
+                    if (tokenId > _sequentialUpTo()) return _ownershipAt(tokenId);
                 }
                 if (tokenId < _nextTokenId()) {
                     // If the `tokenId` is within bounds,

--- a/contracts/mocks/ERC721ASpotMock.sol
+++ b/contracts/mocks/ERC721ASpotMock.sol
@@ -38,10 +38,6 @@ contract ERC721ASpotMock is StartTokenIdHelper, SequentialUpToHelper, ERC721AQue
         _safeMintSpot(to, tokenId);
     }
 
-    function getOwnershipAt(uint256 index) public view returns (TokenOwnership memory) {
-        return _ownershipAt(index);
-    }
-
     function totalSpotMinted() public view returns (uint256) {
         return _totalSpotMinted();
     }

--- a/contracts/mocks/ERC721ASpotMock.sol
+++ b/contracts/mocks/ERC721ASpotMock.sol
@@ -34,6 +34,10 @@ contract ERC721ASpotMock is StartTokenIdHelper, SequentialUpToHelper, ERC721AQue
         return _exists(tokenId);
     }
 
+    function getOwnershipOf(uint256 index) public view returns (TokenOwnership memory) {
+        return _ownershipOf(index);
+    }
+
     function safeMintSpot(address to, uint256 tokenId) public {
         _safeMintSpot(to, tokenId);
     }

--- a/contracts/mocks/ERC721ASpotMock.sol
+++ b/contracts/mocks/ERC721ASpotMock.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+// ERC721A Contracts v4.2.3
+// Creators: Chiru Labs
+
+pragma solidity ^0.8.4;
+
+import './ERC721AQueryableMock.sol';
+import './StartTokenIdHelper.sol';
+import './SequentialUpToHelper.sol';
+
+contract ERC721ASpotMock is StartTokenIdHelper, SequentialUpToHelper, ERC721AQueryableMock {
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint256 startTokenId_,
+        uint256 sequentialUpTo_,
+        uint256 quantity,
+        bool mintInConstructor
+    ) StartTokenIdHelper(startTokenId_) SequentialUpToHelper(sequentialUpTo_) ERC721AQueryableMock(name_, symbol_) {
+        if (mintInConstructor) {
+            _mintERC2309(msg.sender, quantity);
+        }
+    }
+
+    function _startTokenId() internal view override returns (uint256) {
+        return startTokenId();
+    }
+
+    function _sequentialUpTo() internal view override returns (uint256) {
+        return sequentialUpTo();
+    }
+
+    function exists(uint256 tokenId) public view returns (bool) {
+        return _exists(tokenId);
+    }
+
+    function safeMintSpot(address to, uint256 tokenId) public {
+        _safeMintSpot(to, tokenId);
+    }
+
+    function getOwnershipAt(uint256 index) public view returns (TokenOwnership memory) {
+        return _ownershipAt(index);
+    }
+
+    function totalSpotMinted() public view returns (uint256) {
+        return _totalSpotMinted();
+    }
+
+    function totalMinted() public view returns (uint256) {
+        return _totalMinted();
+    }
+
+    function totalBurned() public view returns (uint256) {
+        return _totalBurned();
+    }
+
+    function numberBurned(address owner) public view returns (uint256) {
+        return _numberBurned(owner);
+    }
+
+    function setExtraDataAt(uint256 tokenId, uint24 value) public {
+        _setExtraDataAt(tokenId, value);
+    }
+
+    function _extraData(
+        address,
+        address,
+        uint24 previousExtraData
+    ) internal view virtual override returns (uint24) {
+        return previousExtraData;
+    }
+}

--- a/contracts/mocks/SequentialUpToHelper.sol
+++ b/contracts/mocks/SequentialUpToHelper.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+// ERC721A Contracts v4.2.3
+// Creators: Chiru Labs
+
+pragma solidity ^0.8.4;
+
+/**
+ * This Helper is used to return a dynamic value in the overridden _sequentialUpTo() function.
+ * Extending this Helper before the ERC721A contract give us access to the herein set `sequentialUpTo`
+ * to be returned by the overridden `_sequentialUpTo()` function of ERC721A in the ERC721ASpot mocks.
+ */
+contract SequentialUpToHelper {
+    // `bytes4(keccak256('sequentialUpTo'))`.
+    uint256 private constant SEQUENTIAL_UP_TO_STORAGE_SLOT = 0x9638c59e;
+
+    constructor(uint256 sequentialUpTo_) {
+        _initializeSequentialUpTo(sequentialUpTo_);
+    }
+
+    function sequentialUpTo() public view returns (uint256 result) {
+        assembly {
+            result := sload(SEQUENTIAL_UP_TO_STORAGE_SLOT)
+        }
+    }
+
+    function _initializeSequentialUpTo(uint256 value) private {
+        // We use assembly to directly set the `sequentialUpTo` in storage so that
+        // inheriting this class won't affect the layout of other storage slots.
+        assembly {
+            sstore(SEQUENTIAL_UP_TO_STORAGE_SLOT, value)
+        }
+    }
+}

--- a/test/extensions/ERC721ASpot.test.js
+++ b/test/extensions/ERC721ASpot.test.js
@@ -1,0 +1,234 @@
+const { deployContract } = require('../helpers.js');
+const { expect } = require('chai');
+const { BigNumber } = require('ethers');
+const { constants } = require('@openzeppelin/test-helpers');
+const { ZERO_ADDRESS } = constants;
+
+describe('ERC721ASpot', function () {
+
+  context('constructor', function () {
+    const testConstructor = async (args, expectedError) => {
+      const deployment = deployContract('ERC721ASpotMock', args);
+      if (expectedError) await expect(deployment).to.be.revertedWith(expectedError);  
+      else await deployment;
+    };
+    
+    it('reverts if _sequentialUpTo is not greater than _startTokenId', async function () {
+      const t = async (startTokenId, sequentialUpTo, expectSuccess) => {
+        await testConstructor(
+          ['Azuki', 'AZUKI', startTokenId, sequentialUpTo, 0, false], 
+          expectSuccess ? false : 'SequentialUpToTooSmall'
+        );
+      };
+      await t(0, 0, true);
+      await t(1, 0, false);
+      await t(0, 1, true);
+      await t(100, 99, false);
+      await t(100, 100, true);
+      await t(100, 101, true);
+      await t(100, 999, true);
+    });
+
+    it('reverts if ERC2309 mint exceeds limit', async function () {
+      const t = async (startTokenId, sequentialUpTo, quantity, expectSuccess) => {
+        await testConstructor(
+          ['Azuki', 'AZUKI', startTokenId, sequentialUpTo, quantity, true], 
+          expectSuccess ? false : 'SequentialMintExceedsLimit'
+        );
+      };
+      await t(0, 1, 1, true);
+      await t(0, 1, 2, true);
+      await t(0, 1, 3, false);
+      await t(100, 101, 1, true);
+      await t(100, 101, 2, true);
+      await t(100, 101, 3, false);
+      await t(100, 109, 2, true);
+      await t(100, 109, 9, true);
+      await t(100, 109, 10, true);
+      await t(100, 109, 11, false);
+    });
+  });
+
+  context('mint sequential and spot', function () {
+    beforeEach(async function () {
+      const [owner, addr1] = await ethers.getSigners();
+      this.owner = owner;
+      this.addr1 = addr1;
+      this.startTokenId = BigNumber.from(10);
+      this.sequentialUpTo = BigNumber.from(19);
+      const args = ['Azuki', 'AZUKI', this.startTokenId, this.sequentialUpTo, 0, false];
+      this.erc721aSpot = await deployContract('ERC721ASpotMock', args);
+    });
+
+    it('increases _totalSpotMinted, totalSupply', async function () {
+      await this.erc721aSpot.safeMint(this.addr1.address, 5);
+      expect(await this.erc721aSpot.totalSpotMinted()).to.eq(0);
+      expect(await this.erc721aSpot.totalSupply()).to.eq(5);
+
+      await this.erc721aSpot.safeMintSpot(this.addr1.address, 20);
+      expect(await this.erc721aSpot.totalSpotMinted()).to.eq(1);
+      expect(await this.erc721aSpot.totalSupply()).to.eq(6);
+
+      await this.erc721aSpot.safeMintSpot(this.addr1.address, 30);
+      expect(await this.erc721aSpot.totalSpotMinted()).to.eq(2);
+      expect(await this.erc721aSpot.totalSupply()).to.eq(7);
+    });
+
+    it('tokensOfOwnerIn', async function () {
+      await this.erc721aSpot.safeMint(this.addr1.address, 5);
+      expect(await this.erc721aSpot.tokensOfOwnerIn(this.addr1.address, 0, 50))
+        .to.eql([10, 11, 12, 13, 14].map(BigNumber.from));
+      
+      await this.erc721aSpot.safeMintSpot(this.addr1.address, 21);
+      expect(await this.erc721aSpot.tokensOfOwnerIn(this.addr1.address, 0, 50))
+        .to.eql([10, 11, 12, 13, 14, 21].map(BigNumber.from));
+      
+      await this.erc721aSpot.safeMintSpot(this.addr1.address, 31);
+      expect(await this.erc721aSpot.tokensOfOwnerIn(this.addr1.address, 0, 50))
+        .to.eql([10, 11, 12, 13, 14, 21, 31].map(BigNumber.from));
+      
+      await this.erc721aSpot.safeMintSpot(this.addr1.address, 22);
+      expect(await this.erc721aSpot.tokensOfOwnerIn(this.addr1.address, 0, 50))
+        .to.eql([10, 11, 12, 13, 14, 21, 22, 31].map(BigNumber.from));
+      
+      await this.erc721aSpot.safeMint(this.addr1.address, 5);
+      expect(await this.erc721aSpot.tokensOfOwnerIn(this.addr1.address, 0, 50))
+        .to.eql([10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 31].map(BigNumber.from));
+
+      await this.erc721aSpot.safeMintSpot(this.addr1.address, 20);
+      expect(await this.erc721aSpot.tokensOfOwnerIn(this.addr1.address, 0, 50))
+        .to.eql([10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 31].map(BigNumber.from));
+    });
+
+    it('explicitOwnershipOf', async function () {
+      let explicitOwnership = await this.erc721aSpot.explicitOwnershipOf(10);
+      expect(explicitOwnership.addr).to.eq(ZERO_ADDRESS);
+      expect(explicitOwnership.burned).to.eq(false);
+
+      await this.erc721aSpot.safeMint(this.addr1.address, 1);
+      explicitOwnership = await this.erc721aSpot.explicitOwnershipOf(10);
+      expect(explicitOwnership.addr).to.eq(this.addr1.address);
+      expect(explicitOwnership.burned).to.eq(false);
+
+      explicitOwnership = await this.erc721aSpot.explicitOwnershipOf(11);
+      expect(explicitOwnership.addr).to.eq(ZERO_ADDRESS);
+      expect(explicitOwnership.burned).to.eq(false);
+
+      explicitOwnership = await this.erc721aSpot.explicitOwnershipOf(20);
+      expect(explicitOwnership.addr).to.eq(ZERO_ADDRESS);
+      expect(explicitOwnership.burned).to.eq(false);
+
+      await this.erc721aSpot.safeMintSpot(this.addr1.address, 20);
+      explicitOwnership = await this.erc721aSpot.explicitOwnershipOf(20);
+      expect(explicitOwnership.addr).to.eq(this.addr1.address);
+      expect(explicitOwnership.burned).to.eq(false);
+    });
+
+    it('tokensOfOwner reverts', async function () {
+      await expect(this.erc721aSpot.tokensOfOwner(this.addr1.address)).to.be.revertedWith(
+        'NotCompatibleWithSpotMints'
+      );
+    });
+
+    it('spot minting to an existing token reverts', async function () {
+      await this.erc721aSpot.safeMintSpot(this.addr1.address, 20);
+      await expect(this.erc721aSpot.safeMintSpot(this.addr1.address, 20)).to.be.revertedWith(
+        'TokenAlreadyExists'
+      );
+    });
+
+    it('sequential mints exceeding limit reverts', async function () {
+      await expect(this.erc721aSpot.safeMint(this.addr1.address, 11)).to.be.revertedWith(
+        'SequentialMintExceedsLimit'
+      );
+      await this.erc721aSpot.safeMint(this.addr1.address, 10);
+    });
+
+    context('with burns', function () {
+      beforeEach(async function () {
+        await this.erc721aSpot.safeMint(this.addr1.address, 5);
+        await this.erc721aSpot.safeMintSpot(this.addr1.address, 20);
+        await this.erc721aSpot.safeMintSpot(this.addr1.address, 30);
+      });
+
+      it('reduces balanceOf, totalSupply', async function () {
+        expect(await this.erc721aSpot.balanceOf(this.addr1.address)).to.eq(7);
+        await this.erc721aSpot.connect(this.addr1).burn(10);
+        expect(await this.erc721aSpot.balanceOf(this.addr1.address)).to.eq(6);
+        expect(await this.erc721aSpot.totalSupply()).to.eq(6);
+        
+        await this.erc721aSpot.connect(this.addr1).burn(20);
+        expect(await this.erc721aSpot.balanceOf(this.addr1.address)).to.eq(5);
+        expect(await this.erc721aSpot.totalSupply()).to.eq(5);
+        
+        await this.erc721aSpot.connect(this.addr1).burn(30);
+        expect(await this.erc721aSpot.balanceOf(this.addr1.address)).to.eq(4);
+        expect(await this.erc721aSpot.totalSupply()).to.eq(4);
+
+        await this.erc721aSpot.connect(this.addr1).burn(11);
+        await this.erc721aSpot.connect(this.addr1).burn(12);
+        await this.erc721aSpot.connect(this.addr1).burn(13);
+        await this.erc721aSpot.connect(this.addr1).burn(14);
+        expect(await this.erc721aSpot.balanceOf(this.addr1.address)).to.eq(0);
+        expect(await this.erc721aSpot.totalSupply()).to.eq(0);
+      });
+
+      it('does not reduce totalMinted', async function () {
+        expect(await this.erc721aSpot.balanceOf(this.addr1.address)).to.eq(7);
+        await this.erc721aSpot.connect(this.addr1).burn(10);
+        expect(await this.erc721aSpot.totalMinted()).to.eq(7);
+        
+        await this.erc721aSpot.connect(this.addr1).burn(20);
+        expect(await this.erc721aSpot.totalMinted()).to.eq(7);
+        
+        await this.erc721aSpot.connect(this.addr1).burn(30);
+        expect(await this.erc721aSpot.totalMinted()).to.eq(7);
+      });
+
+      it('increases _numberBurned, totalBurned', async function () {
+        expect(await this.erc721aSpot.balanceOf(this.addr1.address)).to.eq(7);
+        await this.erc721aSpot.connect(this.addr1).burn(10);
+        expect(await this.erc721aSpot.numberBurned(this.addr1.address)).to.eq(1);
+        expect(await this.erc721aSpot.totalBurned()).to.eq(1);
+        
+        await this.erc721aSpot.connect(this.addr1).burn(20);
+        expect(await this.erc721aSpot.numberBurned(this.addr1.address)).to.eq(2);
+        expect(await this.erc721aSpot.totalBurned()).to.eq(2);
+        
+        await this.erc721aSpot.connect(this.addr1).burn(30);
+        expect(await this.erc721aSpot.numberBurned(this.addr1.address)).to.eq(3);
+        expect(await this.erc721aSpot.totalBurned()).to.eq(3);
+
+        await this.erc721aSpot.connect(this.addr1).burn(11);
+        await this.erc721aSpot.connect(this.addr1).burn(12);
+        await this.erc721aSpot.connect(this.addr1).burn(13);
+        await this.erc721aSpot.connect(this.addr1).burn(14);
+        expect(await this.erc721aSpot.numberBurned(this.addr1.address)).to.eq(7);
+        expect(await this.erc721aSpot.totalBurned()).to.eq(7);
+      });
+
+      it('forwards extraData after burn and re-mint', async function () {
+        await this.erc721aSpot.setExtraDataAt(20, 123);
+        let explicitOwnership = await this.erc721aSpot.explicitOwnershipOf(20);
+        expect(explicitOwnership.addr).to.eq(this.addr1.address);
+        expect(explicitOwnership.burned).to.eq(false);
+        expect(explicitOwnership.extraData).to.eq(123);
+        expect(await this.erc721aSpot.exists(20)).to.eq(true);
+
+        await this.erc721aSpot.connect(this.addr1).burn(20);
+        explicitOwnership = await this.erc721aSpot.explicitOwnershipOf(20);
+        expect(explicitOwnership.addr).to.eq(this.addr1.address);
+        expect(explicitOwnership.burned).to.eq(true);
+        expect(explicitOwnership.extraData).to.eq(123);
+        expect(await this.erc721aSpot.exists(20)).to.eq(false);
+
+        this.erc721aSpot.safeMintSpot(this.owner.address, 20);
+        explicitOwnership = await this.erc721aSpot.explicitOwnershipOf(20);
+        expect(explicitOwnership.addr).to.eq(this.owner.address);
+        expect(explicitOwnership.burned).to.eq(false);
+        expect(explicitOwnership.extraData).to.eq(123);
+        expect(await this.erc721aSpot.exists(20)).to.eq(true);
+      });
+    });
+  });
+});

--- a/test/extensions/ERC721ASpot.test.js
+++ b/test/extensions/ERC721ASpot.test.js
@@ -165,11 +165,8 @@ describe('ERC721ASpot', function () {
     });
 
     context('with transfers', function () {
-      beforeEach(async function () {
-        await this.erc721aSpot.safeMint(this.addr1.address, 5);
-      });
-
       it('reverts if token is not minted', async function () {
+        await this.erc721aSpot.safeMint(this.addr1.address, 10);
         await expect(this.erc721aSpot
           .connect(this.addr1)
           .transferFrom(this.addr1.address, this.owner.address, 21)).to.be.revertedWith(
@@ -179,6 +176,32 @@ describe('ERC721ASpot', function () {
         await this.erc721aSpot
           .connect(this.addr1)
           .transferFrom(this.addr1.address, this.owner.address, 21);
+      });
+
+      it('edge case 1', async function () {
+        await this.erc721aSpot.safeMintSpot(this.addr1.address, 20);
+        await this.erc721aSpot.safeMint(this.addr1.address, 10);
+        await this.erc721aSpot.connect(this.addr1).transferFrom(this.addr1.address, this.owner.address, 20);
+        expect(await this.erc721aSpot.ownerOf(20)).to.eq(this.owner.address);
+        expect(await this.erc721aSpot.ownerOf(19)).to.eq(this.addr1.address);
+        expect(await this.erc721aSpot.ownerOf(18)).to.eq(this.addr1.address);
+        await this.erc721aSpot.connect(this.addr1).transferFrom(this.addr1.address, this.owner.address, 19);
+        expect(await this.erc721aSpot.ownerOf(20)).to.eq(this.owner.address);
+        expect(await this.erc721aSpot.ownerOf(19)).to.eq(this.owner.address);
+        expect(await this.erc721aSpot.ownerOf(18)).to.eq(this.addr1.address);
+      });
+
+      it('edge case 2', async function () {
+        await this.erc721aSpot.safeMintSpot(this.addr1.address, 20);
+        await this.erc721aSpot.safeMint(this.addr1.address, 10);
+        await this.erc721aSpot.connect(this.addr1).transferFrom(this.addr1.address, this.owner.address, 19);
+        expect(await this.erc721aSpot.ownerOf(20)).to.eq(this.addr1.address);
+        expect(await this.erc721aSpot.ownerOf(19)).to.eq(this.owner.address);
+        expect(await this.erc721aSpot.ownerOf(18)).to.eq(this.addr1.address);
+        await this.erc721aSpot.connect(this.addr1).transferFrom(this.addr1.address, this.owner.address, 20);
+        expect(await this.erc721aSpot.ownerOf(20)).to.eq(this.owner.address);
+        expect(await this.erc721aSpot.ownerOf(19)).to.eq(this.owner.address);
+        expect(await this.erc721aSpot.ownerOf(18)).to.eq(this.addr1.address);
       });
     });
 

--- a/test/extensions/ERC721ASpot.test.js
+++ b/test/extensions/ERC721ASpot.test.js
@@ -189,13 +189,17 @@ describe('ERC721ASpot', function () {
         await this.erc721aSpot.safeMintSpot(this.addr1.address, 30);
       });
 
-      it.only('sets ownership correctly', async function () {
-        const tokenIds = [10,11,12,13,14,20,30];
-        for (let i = 0; i < 35; ++i) {
-          const tx = this.erc721aSpot.getOwnershipOf(i);
-          if (tokenIds.includes(i)) await tx;
-          else await expect(tx).to.be.revertedWith('OwnerQueryForNonexistentToken');
-        }
+      it('sets ownership correctly', async function () {
+        const t = async (tokenIds) => {
+          for (let i = 0; i < 35; ++i) {
+            const tx = this.erc721aSpot.getOwnershipOf(i);
+            if (tokenIds.includes(i)) await tx;
+            else await expect(tx).to.be.revertedWith('OwnerQueryForNonexistentToken');
+          }
+        };
+        await t([10, 11, 12, 13, 14, 20, 30]);
+        await this.erc721aSpot.connect(this.addr1).burn(20);
+        await t([10, 11, 12, 13, 14, 30]);
       });
 
       it('reduces balanceOf, totalSupply', async function () {

--- a/test/extensions/ERC721ASpot.test.js
+++ b/test/extensions/ERC721ASpot.test.js
@@ -231,30 +231,38 @@ describe('ERC721ASpot', function () {
         expect(await this.erc721aSpot.totalBurned()).to.eq(7);
       });
 
-      it('forwards extraData after burn and re-mint', async function () {
-        await this.erc721aSpot.setExtraDataAt(20, 123);
-        let explicitOwnership = await this.erc721aSpot.explicitOwnershipOf(20);
-        expect(await this.erc721aSpot.exists(20)).to.eq(true);
-        expect(explicitOwnership.addr).to.eq(this.addr1.address);
-        expect(explicitOwnership.burned).to.eq(false);
-        expect(explicitOwnership.extraData).to.eq(123);
+      it('affects _exists', async function () {
+        expect(await this.erc721aSpot.exists(0)).to.eq(false);
+        expect(await this.erc721aSpot.exists(9)).to.eq(false);
+        expect(await this.erc721aSpot.exists(10)).to.eq(true);
+        
         expect(await this.erc721aSpot.exists(20)).to.eq(true);
 
         await this.erc721aSpot.connect(this.addr1).burn(20);
         expect(await this.erc721aSpot.exists(20)).to.eq(false);
+
+        this.erc721aSpot.safeMintSpot(this.owner.address, 20);
+        expect(await this.erc721aSpot.exists(20)).to.eq(true);
+      });
+
+      it('forwards extraData after burn and re-mint', async function () {
+        await this.erc721aSpot.setExtraDataAt(20, 123);
+        let explicitOwnership = await this.erc721aSpot.explicitOwnershipOf(20);
+        expect(explicitOwnership.addr).to.eq(this.addr1.address);
+        expect(explicitOwnership.burned).to.eq(false);
+        expect(explicitOwnership.extraData).to.eq(123);
+
+        await this.erc721aSpot.connect(this.addr1).burn(20);
         explicitOwnership = await this.erc721aSpot.explicitOwnershipOf(20);
         expect(explicitOwnership.addr).to.eq(this.addr1.address);
         expect(explicitOwnership.burned).to.eq(true);
         expect(explicitOwnership.extraData).to.eq(123);
-        expect(await this.erc721aSpot.exists(20)).to.eq(false);
 
         this.erc721aSpot.safeMintSpot(this.owner.address, 20);
-        expect(await this.erc721aSpot.exists(20)).to.eq(true);
         explicitOwnership = await this.erc721aSpot.explicitOwnershipOf(20);
         expect(explicitOwnership.addr).to.eq(this.owner.address);
         expect(explicitOwnership.burned).to.eq(false);
         expect(explicitOwnership.extraData).to.eq(123);
-        expect(await this.erc721aSpot.exists(20)).to.eq(true);
       });
     });
   });


### PR DESCRIPTION
This PR gives ERC721A the ability to mint tokens in non-sequential order. 

Devs will need to override a new `_sequentialUpTo()` function to return a value less than `2**256 - 1` to activate this feature.  

About:
- Sequential mint: `_startTokenId() <= tokenId <= _sequentialUpTo()`
- Spot (i.e. non-sequential) mint: `_sequentialUpTo() < tokenId`.

Zero-cost abstraction:
- If `_sequentialUpTo() == type(uint256).max` (by default), all expressions of `x > _sequentialUpTo()`, `x != _sequentialUpTo()` will evaluate to false on compile time, and the dead code will be removed. If you don't override `_sequentialUpTo()`, you won't pay any extra gas.

Notes:
- "Non-sequential" is a mouthful to type. ChatGPT suggests that "spot" is a short word that conveys similar meaning as non-sequential. 
- The new storage variable for the total number of spot mints is placed at the end of all the storage variables, so that we can maintain storage compatibility with the current ERC721AUpgradeable.
- Most functionality of `ERC721AQueryable` can still be used with spot mints. The `tokensOfOwner` function is disabled if spot mints is enabled, as it would need to scan the entire uint256 range, which is unfeasible. The `tokensOfOwnerIn` function, however, is still available for use with spot mints, as the search range can be manually restricted. Added some minor optimizations to the scanning logic.

Todo: 
- Reason really hard about the code.