### PR TITLE
Update docs for TokenOwnership struct

### DIFF
--- a/docs/erc721a.md
+++ b/docs/erc721a.md
@@ -24,6 +24,8 @@ struct TokenOwnership {
     uint64 startTimestamp;
     // Whether the token has been burned.
     bool burned;
+    // Arbitrary data similar to `startTimestamp` that can be set via {_extraData}.
+    uint24 extraData;
 }
 ```
 


### PR DESCRIPTION
The `extraData` field wasn't documented in the official docs but exists in the data field for the contract.